### PR TITLE
dbConnect를 제거하고 executeQuery를 만들었습니다.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,7 @@
   "name": "42-jiphyeonjeon-backend-3rd",
   "version": "1.0.0",
   "description": "3rd of 42-jiphyeonjeon web service backend",
-  "main": "index.js",
+  "main": "./dist/server.js",
   "repository": "https://github.com/jiphyeonjeon-42/backend-express.git",
   "author": "jolim, chanykim, tkim, jimin, wocho",
   "license": "MIT",

--- a/backend/src/mysql.ts
+++ b/backend/src/mysql.ts
@@ -1,5 +1,7 @@
 import mysql from 'mysql2/promise';
+import { FieldPacket } from 'mysql2';
 import config from './config';
+import { logger } from './utils/logger';
 
 export const pool = mysql.createPool({
   host: config.database.host,
@@ -9,9 +11,15 @@ export const pool = mysql.createPool({
   database: config.database.dbName,
 });
 
-export const dbConnect = async () => {
+export const executeQuery = async (queryText: string, values: any[] = []): Promise<any> => {
   const connection = await pool.getConnection();
-  return connection;
+  logger.debug(`Executing query: ${queryText} (${values})`);
+  const [result]: [
+    any,
+    FieldPacket[]
+  ] = await connection.query(queryText, values);
+  connection.release();
+  return result;
 };
 
 type lending = {


### PR DESCRIPTION
Closes #26 
### 개요
dbConnect는 connection.release()를 호출하지 않는 문제점이 있습니다. 함수를 1회 실행할 때마다 release를 하는 executeQuery함수를 만들었습니다.

### 작업 사항
dbConnect를 없애고 executeQuery 함수를 만들었습니다.
dbConnect와 connection의 자리를 모두 executeQuery로 변경했습니다.

### 변경점
여러 번 service들을 호출했을 때 db연결이 제대로 되지 않는 오류가 사라졌습니다.

### 목적
db연결을 제대로 하게 하기 위함
