### PR TITLE
책 개별 조회 서비스, 라우트, 컨트롤러, api 적용

### DIFF
--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -3,7 +3,7 @@ import {
 } from 'express';
 import * as status from 'http-status';
 import ErrorResponse from '../errorResponse';
-import * as BooksSerice from './books.service';
+import * as BooksService from './books.service';
 
 export interface SearchBookInfoQuery {
   query: string,
@@ -25,14 +25,22 @@ export const searchBookInfo = async (
     next(new ErrorResponse(status.BAD_REQUEST, 'query, page, limit 중 하나 이상이 없습니다.'));
   } else {
     res.status(status.OK).json(
-      await BooksSerice.searchInfo(query, sort, parseInt(page, 10), parseInt(limit, 10), category),
+      await BooksService.searchInfo(query, sort, parseInt(page, 10), parseInt(limit, 10), category),
     );
   }
 };
 
-export const infoId: RequestHandler = (req: Request, res: Response) => {
-  res.send('hello express');
-  // search 함수
+export const getInfoId: RequestHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const bookId = parseInt(req.params.id, 10);
+  if (Number.isNaN(bookId)) {
+    next(new ErrorResponse(status.BAD_REQUEST, 'id가 숫자가 아닙니다.'));
+  } else {
+    res.status(status.OK).json(await BooksService.getInfo(bookId));
+  }
 };
 export const info: RequestHandler = (req: Request, res: Response) => {};
 

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import {
-  searchBookInfo, infoId, info, booker, search,
+  searchBookInfo, info, booker, search, getInfoId,
 } from '../books/books.controller';
 
 export const path = '/books';
@@ -43,7 +43,7 @@ router
  *        schema:
  *          type: string
  *      responses:
- *        200:
+ *        '200':
  *          description: 검색 결과를 반환한다.
  *          content:
  *            application/json:
@@ -109,7 +109,7 @@ router
  *                          description: 검색된 개수
  *                          type: integer
  *                          example: 1
- *        400:
+ *        '400':
  *          description: query, page, limit 중 하나 이상이 없다.
  *          content:
  *            application/json:
@@ -118,9 +118,96 @@ router
  *                description: error decription
  *                example: query, page, limit 중 하나 이상이 없습니다.
  */
-
   .get('/info/search', searchBookInfo)
-  .get('/info/:id', infoId)
+
+/**
+ * @openapi
+ * /api/books/info/{id}:
+ *    get:
+ *      description: 책 한 종류의 정보를 가져온다.
+ *      parameters:
+ *      - name: id
+ *        in: path
+ *        description: 책의 id
+ *        required: true
+ *        schema:
+ *          type: integer
+ *      responses:
+ *        '200':
+ *          description: 조회 결과를 반환한다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  id:
+ *                    description: 책의 id
+ *                    type: integer
+ *                    example: 4261
+ *                  title:
+ *                    description: 제목
+ *                    type: string
+ *                    example: 12가지 인생의 법칙
+ *                  author:
+ *                    description: 저자
+ *                    type: string
+ *                    example: 조던 B. 피터슨
+ *                  publisher:
+ *                    description: 출판사
+ *                    type: string
+ *                    example: 메이븐
+ *                  image:
+ *                    description: 이미지 주소
+ *                    type: string
+ *                    example: https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F3943658%3Ftimestamp%3D20210706194852
+ *                  category:
+ *                    description: 카테고리
+ *                    type: string
+ *                    example: 프로그래밍
+ *                  publishedAt:
+ *                    description: 출판일자
+ *                    type: string
+ *                    example: 2018년 10월
+ *                  isbn:
+ *                    descriptoin: isbn
+ *                    type: string
+ *                    example: '9791196067694'
+ *                  donators:
+ *                    descriptoin: 기부자
+ *                    type: string
+ *                    example: hyekim, tkim, jwoo, minkykim
+ *                  books:
+ *                    description: 비치된 책들
+ *                    type: array
+ *                    items:
+ *                      type: object
+ *                      properties:
+ *                        id:
+ *                          description: 실물 책의 id
+ *                          type: integer
+ *                          example: 3
+ *                        callSign:
+ *                          description: 청구기호
+ *                          type: string
+ *                          example: h1.18.v1.c1
+ *                        status:
+ *                          description: 책의 상태
+ *                          type: string
+ *                          example: 비치 중
+ *                        dueDate:
+ *                          description: 반납 예정 일자
+ *                          type: string
+ *                          example: 21.08.05
+ *        '400':
+ *          description: id가 숫자가 아니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: string
+ *                description: error decription
+ *                example: id가 숫자가 아닙니다.
+ */
+  .get('/info/:id', getInfoId)
   .get('/info', info)
   .get('/:id/reservations/count', booker)
   .get('/search', search);


### PR DESCRIPTION
### 개요
close #30.
책을 개별로 조회하는 서비스를 만들었습니다.

### 작업 사항
api페이지의 '상세 페이지'에 해당합니다.

### 변경점

### 목적

### 스크린샷 (optional)
<img width="910" alt="image" src="https://user-images.githubusercontent.com/3518710/160367711-03872112-f09b-41d8-90ed-a20e8f42dfd5.png">
