### PR TITLE
JIP-93 executeQuery가 적절하게 에러를 던집니다.

### DIFF
--- a/backend/src/mysql.ts
+++ b/backend/src/mysql.ts
@@ -14,11 +14,44 @@ export const pool = mysql.createPool({
 export const executeQuery = async (queryText: string, values: any[] = []): Promise<any> => {
   const connection = await pool.getConnection();
   logger.debug(`Executing query: ${queryText} (${values})`);
-  const [result]: [
-    any,
-    FieldPacket[]
-  ] = await connection.query(queryText, values);
-  connection.release();
+  let result;
+  try {
+    const queryResult: [
+      any,
+      FieldPacket[]
+    ] = await connection.query(queryText, values);
+    [result] = queryResult;
+  } catch (e) {
+    if (e instanceof Error) {
+      logger.error(e.message);
+      throw new Error('DB error');
+    }
+    throw e;
+  } finally {
+    connection.release();
+  }
+  return result;
+};
+
+export const makeExecuteQuery = (connection: mysql.PoolConnection) => async (
+  queryText: string,
+  values: any[] = [],
+): Promise<any> => {
+  logger.debug(`Executing query: ${queryText} (${values})`);
+  let result;
+  try {
+    const queryResult: [
+        any,
+        FieldPacket[]
+    ] = await connection.query(queryText, values);
+    [result] = queryResult;
+  } catch (e) {
+    if (e instanceof Error) {
+      logger.error(e.message);
+      throw new Error('DB error');
+    }
+    throw e;
+  }
   return result;
 };
 

--- a/backend/src/mysql.ts
+++ b/backend/src/mysql.ts
@@ -3,6 +3,8 @@ import { FieldPacket } from 'mysql2';
 import config from './config';
 import { logger } from './utils/logger';
 
+export const DBError = 'DB error';
+
 export const pool = mysql.createPool({
   host: config.database.host,
   port: 3306,
@@ -48,7 +50,7 @@ export const makeExecuteQuery = (connection: mysql.PoolConnection) => async (
   } catch (e) {
     if (e instanceof Error) {
       logger.error(e.message);
-      throw new Error('DB error');
+      throw new Error(DBError);
     }
     throw e;
   }


### PR DESCRIPTION
### 개요
executeQuery가 적절하게 에러를 던집니다.

### 작업 사항

### 변경점
executeQuery 내 query문에서 에러가 있을 시 logger.error로 로그하고 DBError = 'DB error'라는 에러를 던집니다.

### 목적
DB에러가 서버 밖으로 노출되는 경우를 방지하기 위해서입니다.

### 스크린샷 (optional)
