### PR TITLE
JIP-183 books info search

### DIFF
--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -320,7 +320,7 @@ export const searchInfo = async (
     `
     SELECT
       IFNULL(category.name, "ALL") AS name,
-      count(name) AS count
+      count(category.name) AS count
     FROM book_info
     LEFT JOIN category ON book_info.categoryId = category.id
     WHERE (
@@ -328,11 +328,11 @@ export const searchInfo = async (
       OR book_info.author LIKE ?
       OR book_info.isbn LIKE ?
       )
-    GROUP BY name WITH ROLLUP ORDER BY category.name ASC;
+    GROUP BY category.name WITH ROLLUP ORDER BY category.name ASC;
   `,
     [`%${query}%`, `%${query}%`, `%${query}%`],
   )) as models.categoryCount[];
-  const categoryHaving = categoryName ? `category = '${categoryName}'` : 'TRUE';
+  const categoryHaving = categoryName ? `categoryEnum = '${categoryName}'` : 'TRUE';
   const bookList = (await executeQuery(
     `
     SELECT
@@ -369,7 +369,8 @@ export const searchInfo = async (
     [`%${query}%`, `%${query}%`, `%${query}%`, limit, page * limit],
   )) as models.BookInfo[];
 
-  const totalItems = categoryList.reduce((prev, curr) => prev + curr.count, 0);
+  const totalItems = categoryList[0].count;
+  console.log('totalItmes', totalItems);
   const meta = {
     totalItems,
     itemCount: bookList.length,

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -316,9 +316,6 @@ export const searchInfo = async (
     [category],
   )) as StringRows[];
   const categoryName = categoryResult?.[0]?.name;
-  const categoryWhere = categoryName
-    ? `category.name = '${categoryName}'`
-    : 'TRUE';
   const categoryList = (await executeQuery(
     `
     SELECT
@@ -330,8 +327,6 @@ export const searchInfo = async (
       book_info.title LIKE ?
       OR book_info.author LIKE ?
       OR book_info.isbn LIKE ?
-      ) AND (
-        ${categoryWhere}
       )
     GROUP BY name WITH ROLLUP ORDER BY category.name ASC;
   `,


### PR DESCRIPTION
### 개요
 HOTFIX:  books/info/search가 적절하게 동작하도록 수정

### 작업 사항
 1. categoryList가 검색어가 동일하다면 변경되지 않음
 2. totalItem이 검색어 + 카테고리에 해당하는 모든 행의 개수를 반환
 3. ~~category라는 컬럼명이 없어서 categoryEnum으로 변경~~ 휴먼에러였음. 기존 코드가 맞아서 기존코드로 변경
 
### 지라링크
- https://42jiphyeonjeon.atlassian.net/browse/JIP-183?atlOrigin=eyJpIjoiNzNmYjM2YTExYmJmNDgxYzk0NWU0NGFiMzVmZTUxZDQiLCJwIjoiaiJ9
