### PR TITLE
Jip 215 books search meta데이터 수정

### DIFF
--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -71,7 +71,7 @@ export const searchBookInfo = async (
   const {
     page, limit, sort, category,
   } = req.query;
-  if (!(page && limit)) {
+  if (Number.isNaN(page) || Number.isNaN(limit)) {
     return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
   }
   try {
@@ -158,7 +158,7 @@ export const search = async (
   const query = String(req.query.query);
   const page = parseInt(String(req.query.page), 10);
   const limit = parseInt(String(req.query.limit), 10);
-  if (!(query && page && limit)) {
+  if (query === 'undefined' || Number.isNaN(page) || Number.isNaN(limit)) {
     return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
   }
   try {

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -46,7 +46,21 @@ export const search = async (
     [`%${query}%`, `%${query}%`, `%${query}%`, limit, page * limit],
   )) as models.BookInfo[];
 
-  const totalItems = bookList.length;
+  const totalItems = (await executeQuery(
+    `
+    SELECT
+      COUNT(*) AS count
+    FROM book_info
+    INNER JOIN book ON book_info.id = book.infoId
+    WHERE (
+      book_info.title LIKE ?
+      OR book_info.author LIKE ?
+      OR book_info.isbn LIKE ?
+      )
+  `,
+    [`%${query}%`, `%${query}%`, `%${query}%`],
+  ))[0].count as number;
+
   const meta = {
     totalItems,
     itemCount: bookList.length,


### PR DESCRIPTION
### 개요
books/search API 잘못된 meta데이터 totalItmes수정
books controller에서 잘못된 에러처리 수정

### 작업 사항
 1. books/search 에서 totalPage가 제대로 나오도록 totalItmes 수정, totalPage는 `totalPages: Math.ceil(totalItems / limit)` 로 계산됨.
 2. contoller에서 Number.isNaN()를 이용하여 들어온 값이 숫자인지 확인, 기존 코드에서는 0일 경우 (그러면 안되는데) 오류를 반환함.