### PR TITLE
Jip 228 lendings api 버그 수정

### DIFF
--- a/backend/src/lendings/lendings.controller.ts
+++ b/backend/src/lendings/lendings.controller.ts
@@ -48,7 +48,7 @@ export const search: RequestHandler = async (
   next: NextFunction,
 ) => {
   const info = req.query;
-  const query = info.query as string;
+  const query = String(info.query) !== 'undefined' ? String(info.query) : '';
   const page = parseInt(info.page as string, 10) ? parseInt(info.page as string, 10) : 0;
   const limit = parseInt(info.limit as string, 10) ? parseInt(info.limit as string, 10) : 5;
   const sort = info.sort as string;

--- a/backend/src/lendings/lendings.service.ts
+++ b/backend/src/lendings/lendings.service.ts
@@ -200,20 +200,14 @@ export const search = async (
       CASE WHEN NOW() > user.penaltyEndDate THEN 0
         ELSE DATEDIFF(now(), user.penaltyEndDate)
       END AS penaltyDays,
-      (
-          SELECT callSign
-          FROM book
-          WHERE id = bookId
-      ) as callSign,
-      (
-        SELECT title
-        FROM book_info
-        WHERE id = bookId
-      ) AS title,
+      book.callSign,
+      book_info.title,
       lending.createdAt AS createdAt,
       DATE_ADD(lending.createdAt, interval 14 day) AS dueDate
     FROM lending
-    JOIN user AS user ON lending.userId = user.id
+    JOIN user ON  user.id = lending.userId
+    JOIN book ON book.id = lending.bookId
+    JOIN book_info ON book_info.id = book.infoID
     WHERE lending.returnedAt is NULL
     ${filterQuery}
     ORDER BY lending.createdAt ${orderQuery}

--- a/backend/src/lendings/lendings.service.ts
+++ b/backend/src/lendings/lendings.service.ts
@@ -265,17 +265,14 @@ export const lendingId = async (id:number) => {
       WHEN user.penaltyEndDate < NOW() THEN 0
       ELSE DATEDIFF(NOW(), user.penaltyEndDate)
     END AS penaltyDays,
-    (
-        SELECT callSign
-        FROM book
-        WHERE book.id = lending.bookId
-    ) as callSign,
-    book.title as title,
-    book.image as image,
+    book.callSign,
+    book_info.title as title,
+    book_info.image as image,
     DATE_FORMAT(DATE_ADD(lending.createdAt, interval 14 day), '%Y.%m.%d') AS dueDate
     FROM lending
     JOIN user AS user ON user.id = lending.userId
-    JOIN book_info AS book ON book.id = lending.bookId
+    JOIN book ON book.id = lending.bookId
+    JOIN book_info ON book_info.id = book.infoId
     WHERE lending.id = ?
   `, [id]);
   return data[0];


### PR DESCRIPTION
### 개요
lending api에서 조인 조건이 잘못된 부분을 수정
+
빈값을 입력했을 때 전체결과가 반환되도록 기능 추가

### 작업 사항
lending.bookId는 book_info 테이블의 Id가 아니라, book테이블의 id입니다.

-

프론트에서 정상동작 확인했습니다.

### 스크린샷 (optional)
![image](https://user-images.githubusercontent.com/62806979/175824365-d127836a-e3eb-40f2-8280-e8488a9815a1.png)
![image](https://user-images.githubusercontent.com/62806979/175824372-0b661e3e-f458-4805-880b-c545c046861c.png)


### 지라링크
[jira link](https://42jiphyeonjeon.atlassian.net/browse/JIP-228?atlOrigin=eyJpIjoiOTI0OWM1ZmNkYjFjNGQ3NDlhMDljYzc5Y2I3MGY0MjQiLCJwIjoiaiJ9)
