### PR TITLE
JIP-243 청구기호 대소문자 구분하게끔 쿼리 수정

### DIFF
--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -118,7 +118,7 @@ export const createBook = async (book: types.CreateBookInfo) => {
     logger.warn(`${errorCode.SLACKID_OVERLAP}: nickname이 중복입니다. 최근에 가입한 user의 ID로 기부가 기록됩니다.`);
   }
 
-  const callSignExist = (await executeQuery('SELECT COUNT(*) as cnt FROM book WHERE callSign = ? ', [book.callSign])) as StringRows[];
+  const callSignExist = (await executeQuery('SELECT COUNT(*) as cnt FROM book WHERE binary(callSign) = ? ', [book.callSign])) as StringRows[];
   if (callSignExist[0].cnt > 0) {
     throw new Error(errorCode.CALL_SIGN_OVERLAP);
   }


### PR DESCRIPTION
### 개요
비개발도서의 경우 청구기호가 소문자로 시작하고, 개발도서의 경우 청구기호가 대문자로 시작되고 있습니다.

근데, 청구기호 중복 체크시에 대소문자 구분을 하지 않아서, 중복 체크가 제대로 되지 않는 문제가 있는거 같습니다.

예를들어, '네트워크' 카테고리의 새로운 책을 C19.17.v1.c1 으로 등록하면 비개발도서의 c19.17.v1.c1가 존재한다고 하여 등록이 되지 않습니다!

### 작업 사항
- binary로 callSign을 감싸주면 대소문자 구분이 된다고 함

### 변경점

### 목적

### 스크린샷 (optional)
