### PR TITLE
Jip 254 예약 1 순위의 예약만료일이 없는 문제

### DIFF
--- a/backend/src/lendings/lendings.service.ts
+++ b/backend/src/lendings/lendings.service.ts
@@ -136,7 +136,7 @@ export const returnBook = async (
       WHERE id = ?
     `, [librarianId, condition, lendingId]);
 
-    // 예약된 책이 있다면 예약 부여, endAt 어떻게 처리하지..?
+    // 예약된 책이 있다면 예약 부여
     const isReserved = await transactionExecuteQuery(`
       SELECT *
       FROM reservation

--- a/backend/src/lendings/lendings.service.ts
+++ b/backend/src/lendings/lendings.service.ts
@@ -156,8 +156,11 @@ export const returnBook = async (
           endAt =  DATE_ADD(NOW(), INTERVAL 3 DAY)
         WHERE id = ?
     `, [lendingInfo[0].bookId, isReserved[0].id]);
+      // 예약자에게 슬랙메시지 보내기
+      const slackIdReservedUser = (await transactionExecuteQuery('SELECT slack from user where id = ?', [isReserved[0].userId]))[0].slack;
+      const bookTitle = (await transactionExecuteQuery('SELECT title from book_info where id = (SELECT infoId FROM book WHERE id = ?)', [lendingInfo[0].bookId]))[0].title;
+      publishMessage(slackIdReservedUser, `:robot_face: 집현전 봇 :robot_face:\n예약하신 도서 \`${bookTitle}\`(이)가 대출 가능합니다. 3일 내로 집현전에 방문해 대출해주세요.`);
     }
-
     await conn.commit();
   } catch (error) {
     await conn.rollback();

--- a/backend/src/reservations/reservations.controller.ts
+++ b/backend/src/reservations/reservations.controller.ts
@@ -23,7 +23,6 @@ export const create: RequestHandler = async (
       .status(status.OK)
       .json(await reservationsService.create(id, req.body.bookInfoId));
   } catch (error: any) {
-    console.log("error", error);
     const errorNumber = parseInt(error.message, 10);
     if (errorNumber >= 500 && errorNumber < 600) {
       next(new ErrorResponse(error.message, status.BAD_REQUEST));

--- a/backend/src/reservations/reservations.service.ts
+++ b/backend/src/reservations/reservations.service.ts
@@ -89,6 +89,7 @@ export const create = async (userId: number, bookInfoId: number) => {
       INSERT INTO reservation (userId, bookInfoId)
       VALUES (?, ?)
     `, [userId, bookInfoId]);
+    // eslint-disable-next-line no-use-before-define
     const reservationPriorty : any = count(bookInfoId);
     conn.commit();
     return reservationPriorty;


### PR DESCRIPTION
### 개요
 예약 1순위여도 예약 만료일이 없을 수 있음.
 예약 만료일은 대출된 책이 반납되었을 경우에만 생성되기 때문. 

### 작업 사항
 1. 예약이 걸린 책이 반납되었을 경우 예약자에게 슬랙알람을 보냄
 2. console.log와 남아있던 불필요한 주석 삭제
 
### 보충 설명
1순위여도 해당책이 반납되기 전까지는 예약만료일은 없습니다. 
예약된 책을 반납후에 확인해보시면 값이 들어가 있는 것을 확인했습니다.


### 스크린샷 (optional)
![image](https://user-images.githubusercontent.com/62806979/177052378-a9569e19-3dd8-4b9c-9f6b-cc807bae605e.png)
![image](https://user-images.githubusercontent.com/62806979/177052385-6cf8f77c-baa3-4223-9a06-cbe8b1dc39f1.png)
