### PR TITLE
JIP-292 FIX: 대출불가상태는 대출중일 경우만 있는게 아님

### DIFF
--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -441,7 +441,7 @@ export const getInfo = async (id: string) => {
         LIMIT 1;
       `,
           [eachBook.id],
-        ).then((dueDateArr) => dueDateArr[0].dueDate);
+        ).then((dueDateArr) => (dueDateArr[0]?.dueDate ? dueDateArr[0].dueDate : '-'));
       } else {
         dueDate = '-';
       }


### PR DESCRIPTION
### 개요
 book status가 0이 아닐경우 알수없는 에러가 뜨는 문제 해결

기존 코드는 '대출불가'가 모든 책들이 대출중인 경우만 있다는 가정하에 짜여짐.  
 '대출불가'일 경우는 모든 책들이 대출중인 경우뿐만 아니라, 책이 '분실', '파손'일 경우도 포함됨.

### 작업 사항
 1. 옵셔널 체이닝을 이용하여 lending에서 값을 불러올 수 없는 경우에 따로 처리
 
### 스크린샷 (optional)
![image](https://user-images.githubusercontent.com/62806979/177099129-51cc2b03-3493-4fc7-b9e1-ba696001a055.png)
정상 작동 확인