### PR TITLE
Jip 310 reservations search 버그 고치기

### DIFF
--- a/backend/src/reservations/reservations.service.ts
+++ b/backend/src/reservations/reservations.service.ts
@@ -137,11 +137,10 @@ export const
         reservation.endAt AS endAt,
         reservation.status,
         user.id AS userId,
-        book.id AS bookId
+        reservation.bookId AS bookId
       FROM reservation
       LEFT JOIN user ON reservation.userId = user.id
       LEFT JOIN book_info ON reservation.bookInfoId = book_info.id
-      LEFT JOIN book ON book_info.id = book.infoId
       ${filterQuery}
       HAVING book_info.title LIKE ? OR login LIKE ? OR callSign LIKE ?
       LIMIT ?

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -248,7 +248,7 @@ export const router = Router();
  *              schema:
  *                type: object
  *                properties:
- *                  errCode:
+ *                  errorCode:
  *                    type: integer
  *                    example: 200
  *        '500':


### PR DESCRIPTION
### 개요
 기존 쿼리에서는 같은 reservation id에 여러 bookId가 들어가는 문제가 있었습니다. reservation에는 bookId가 하나만 있는게 맞기때문에 쿼리문을 수정했습니다.

### 작업 사항
 불필요하게 book 테이블과 join하는 부분 삭제

### 스크린샷 (optional)
![image](https://user-images.githubusercontent.com/62806979/177360670-c447236c-bbf2-4e83-ad97-05b861247d68.png)
정상 동작 확인