### PR TITLE
JIP-339 FEAT: 42 인증하기 자동으로 회원가입 기능 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -23,18 +23,21 @@ export const getOAuth = (req: Request, res: Response) => {
 
 export const getToken = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
-    const { id } = req.user as any;
+    const { id, nickName } = req.user as any;
     const user: models.User[] = await usersService.searchUserByIntraId(id);
     if (user.length === 0) {
-      res.status(status.BAD_REQUEST)
-        .send(`<script type="text/javascript">window.location="${config.client.clientURL}/register?errorCode=${errorCode.NO_USER}"</script>`);
-      return;
-    }
-    await authJwt.saveJwt(req, res, user[0]);
+      const email = `${nickName}@student.42seoul.kr`;
+      const password = Math.random().toString(36).slice(2); // 랜덤 비밀번호 설정
+      await usersService.createUser(String(email), await bcrypt.hash(String(password), 10));
+      const newUser: { items: models.User[] } = await usersService.searchUserByEmail(email);
+      await authService.updateAuthenticationUser(newUser.items[0].id, id, nickName);
+      await updateSlackIdByUserId(newUser.items[0].id);
+      await authJwt.saveJwt(req, res, newUser.items[0]);
+    } else { await authJwt.saveJwt(req, res, user[0]); }
     res.status(302).redirect(`${config.client.clientURL}/auth`);
   } catch (error: any) {
     const errorNumber = parseInt(error.message ? error.message : error.errorCode, 10);
-    if (errorNumber === 101) { return next(new ErrorResponse(error.message, status.UNAUTHORIZED)); }
+    if (errorNumber === 101) { next(new ErrorResponse(error.message, status.UNAUTHORIZED)); }
     if (errorNumber >= 100 && errorNumber < 200) {
       next(new ErrorResponse(error.message, status.BAD_REQUEST));
     } else if (error.message === 'DB error') {
@@ -109,7 +112,7 @@ export const logout = (req: Request, res: Response) => {
 export const getIntraAuthentication = (req: Request, res: Response) => {
   const clientId = config.client.id;
   const redirectURL = `${config.client.redirectURL}/api/auth/intraAuthentication`;
-  //const redirectURL = `${config.client.redirectURL}/api/auth/token`;
+  // const redirectURL = `${config.client.redirectURL}/api/auth/token`;
   const oauthUrl = `https://api.intra.42.fr/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(
     redirectURL,
   )}&response_type=code`;

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -36,8 +36,11 @@ export const getToken = async (req: Request, res: Response, next: NextFunction):
         await updateSlackIdByUserId(newUser.items[0].id);
         await authJwt.saveJwt(req, res, newUser.items[0]);
       } catch (error: any) {
-        res.status(status.BAD_REQUEST).send(`<script type="text/javascript">window.location="${config.client.clientURL}/register?errorCode=${errorCode.EMAIL_OVERLAP}"</script>`);
-        return;
+        const errorNumber = parseInt(error.message ? error.message : error.errorCode, 10);
+        if (errorNumber === 203) {
+          res.status(status.BAD_REQUEST).send(`<script type="text/javascript">window.location="${config.client.clientURL}/register?errorCode=${errorCode.EMAIL_OVERLAP}"</script>`);
+          return;
+        }
       }
     } else { await authJwt.saveJwt(req, res, user[0]); }
     res.status(302).redirect(`${config.client.clientURL}/auth`);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -37,8 +37,9 @@ export const getToken = async (req: Request, res: Response, next: NextFunction):
     res.status(302).redirect(`${config.client.clientURL}/auth`);
   } catch (error: any) {
     const errorNumber = parseInt(error.message ? error.message : error.errorCode, 10);
-    if (errorNumber === 101) { next(new ErrorResponse(error.message, status.UNAUTHORIZED)); }
-    if (errorNumber >= 100 && errorNumber < 200) {
+    if (errorNumber === 101) {
+      next(new ErrorResponse(error.message, status.UNAUTHORIZED));
+    } else if (errorNumber >= 100 && errorNumber < 200) {
       next(new ErrorResponse(error.message, status.BAD_REQUEST));
     } else if (error.message === 'DB error') {
       next(new ErrorResponse(errorCode.QUERY_EXECUTION_FAILED, status.INTERNAL_SERVER_ERROR));

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -41,6 +41,8 @@ export const getToken = async (req: Request, res: Response, next: NextFunction):
           res.status(status.BAD_REQUEST).send(`<script type="text/javascript">window.location="${config.client.clientURL}/register?errorCode=${errorCode.EMAIL_OVERLAP}"</script>`);
           return;
         }
+        res.status(status.SERVICE_UNAVAILABLE).send(`<script type="text/javascript">window.location="${config.client.clientURL}/register?errorCode=${errorCode.UNKNOWN_ERROR}"</script>`);
+        return;
       }
     } else { await authJwt.saveJwt(req, res, user[0]); }
     res.status(302).redirect(`${config.client.clientURL}/auth`);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -26,20 +26,26 @@ export const getToken = async (req: Request, res: Response, next: NextFunction):
     const { id, nickName } = req.user as any;
     const user: models.User[] = await usersService.searchUserByIntraId(id);
     if (user.length === 0) {
-      const email = `${nickName}@student.42seoul.kr`;
-      const password = Math.random().toString(36).slice(2); // 랜덤 비밀번호 설정
-      await usersService.createUser(String(email), await bcrypt.hash(String(password), 10));
-      const newUser: { items: models.User[] } = await usersService.searchUserByEmail(email);
-      await authService.updateAuthenticationUser(newUser.items[0].id, id, nickName);
-      await updateSlackIdByUserId(newUser.items[0].id);
-      await authJwt.saveJwt(req, res, newUser.items[0]);
+      // 회원가입
+      try {
+        const email = `${nickName}@student.42seoul.kr`;
+        const password = Math.random().toString(36).slice(2); // 랜덤 비밀번호 설정
+        await usersService.createUser(String(email), await bcrypt.hash(String(password), 10));
+        const newUser: { items: models.User[] } = await usersService.searchUserByEmail(email);
+        await authService.updateAuthenticationUser(newUser.items[0].id, id, nickName);
+        await updateSlackIdByUserId(newUser.items[0].id);
+        await authJwt.saveJwt(req, res, newUser.items[0]);
+      } catch (error: any) {
+        res.status(status.BAD_REQUEST).send(`<script type="text/javascript">window.location="${config.client.clientURL}/register?errorCode=${errorCode.EMAIL_OVERLAP}"</script>`);
+        return;
+      }
     } else { await authJwt.saveJwt(req, res, user[0]); }
     res.status(302).redirect(`${config.client.clientURL}/auth`);
   } catch (error: any) {
     const errorNumber = parseInt(error.message ? error.message : error.errorCode, 10);
     if (errorNumber === 101) {
       next(new ErrorResponse(error.message, status.UNAUTHORIZED));
-    } else if (errorNumber >= 100 && errorNumber < 300) {
+    } else if (errorNumber >= 100 && errorNumber < 200) {
       next(new ErrorResponse(error.message, status.BAD_REQUEST));
     } else if (error.message === 'DB error') {
       next(new ErrorResponse(errorCode.QUERY_EXECUTION_FAILED, status.INTERNAL_SERVER_ERROR));

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -39,7 +39,7 @@ export const getToken = async (req: Request, res: Response, next: NextFunction):
     const errorNumber = parseInt(error.message ? error.message : error.errorCode, 10);
     if (errorNumber === 101) {
       next(new ErrorResponse(error.message, status.UNAUTHORIZED));
-    } else if (errorNumber >= 100 && errorNumber < 200) {
+    } else if (errorNumber >= 100 && errorNumber < 300) {
       next(new ErrorResponse(error.message, status.BAD_REQUEST));
     } else if (error.message === 'DB error') {
       next(new ErrorResponse(errorCode.QUERY_EXECUTION_FAILED, status.INTERNAL_SERVER_ERROR));

--- a/backend/src/auth/auth.strategy.ts
+++ b/backend/src/auth/auth.strategy.ts
@@ -10,9 +10,10 @@ export const FtStrategy = new FortyTwoStrategy(
     callbackURL: `${config.client.redirectURL}/api/auth/token`,
   },
   (accessToken: any, refreshToken: any, profile: any, cb: Function) => {
-    const { id } = profile._json; // eslint-disable-line no-underscore-dangle
+    const { id, login } = profile._json; // eslint-disable-line no-underscore-dangle
     const user = {
       id,
+      nickName: login,
     };
     cb(null, user);
   },


### PR DESCRIPTION
### 개요
- 42인증하기 과정에서 회원이 아닐 경우 자동 회원으로 등록

### 작업 사항
- 42인증을 성공했으나 회원이 아닌 경우 새로 DB에 등록하고 관련 정보를 저장합니다.
- 이메일은 nickname +`@student.42seoul.kr` 계정으로 자동 생성합니다.
- 비밀번호는 랜덤으로 생성합니다.
- 인증 과정에서 확인한 intraId 와 nickname을 저장합니다.
- nickname 기준으로 확인한 슬랙 Id도 저장합니다.

### 변경점
- 42인증을 성공한 경우라면 이메일회원가입을 진행하지 않았더라도 에러로 취급하지 않습니다.

### 목적
- 사용자 경험 개선
- 다수의 요청으로 회원가입 절차를 간소화합니다.

### 스크린샷 (optional)
![Jul-12-2022 00-17-31](https://user-images.githubusercontent.com/74622889/178298450-af1c852f-2b0c-4abe-82ad-0e0edb69637b.gif)

