### PR TITLE
FIX: 모든 사람들의 slack id가 제대로 들어가도록 수정

### DIFF
--- a/backend/src/slack/slack.service.ts
+++ b/backend/src/slack/slack.service.ts
@@ -40,12 +40,14 @@ export const updateSlackId = async (): Promise<void> => {
     cursor = response.response_metadata.next_cursor;
   }
   searchUsers.forEach((user) => {
-    const { display_name: displayName } = user.profile;
+    const { real_name: realName } = user.profile;
     const slackUserId = user.id;
-    userMap.set(displayName, slackUserId);
+    userMap.set(realName.toLowerCase(), slackUserId);
   });
   authenticatedUser.forEach((user) => {
-    if (userMap.has(user.nickname)) updateSlackIdUser(user.id, userMap.get(user.nickname));
+    if (userMap.has(user.nickname.toLowerCase())) {
+      updateSlackIdUser(user.id, userMap.get(user.nickname.toLowerCase()));
+    }
   });
 };
 


### PR DESCRIPTION
### 개요
모든 사람들의 slack id가 업데이트될 때 제대로 들어가도록 수정하였습니다.

### 작업 사항
slack api가 주는 정보 중 display_name이 아니라 real_name을 기준으로 slack id를 삽입하도록 바꿨습니다. 또, slack nickname에 대문자가 들어가있는 사람들이 있어서 toLowerCase로 case insensitive 비교를 하도록 했습니다.

### 변경점

### 목적

### 스크린샷 (optional)
