### PR TITLE
JIP 235 get books create 국립중앙도서관 분류기준 정보 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
           BOT_USER_OAUTH_ACCESS_TOKEN=${{ secrets.BOT_USER_OAUTH_ACCESS_TOKEN }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
           NAVER_BOOK_SEARCH_CLIENT_ID=${{ secrets.NAVER_BOOK_SEARCH_CLIENT_ID }}
+          NATION_LIBRARY_KEY=${{ secrets.NATION_LIBRARY_KEY }}
           NAVER_BOOK_SEARCH_SECRET=${{ secrets.NAVER_BOOK_SEARCH_SECRET }}" > .env
           
     - name: Configure AWS credentials

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -81,10 +81,11 @@ const getInfoInNationalLibrary = async (isbn: string) => {
     .then((res) => {
       searchResult = res.data.docs[0];
       const {
-        TITLE: title, TITLE_URL: image, AUTHOR: author, SUBJECT: category,
+        // eslint-disable-next-line max-len
+        TITLE: title, TITLE_URL: image, AUTHOR: author, SUBJECT: category, PUBLISHER: publisher, PUBLISH_PREDATE: pubdate,
       } = searchResult;
       book = {
-        title, image, author, category, isbn,
+        title, image, author, category, isbn, publisher, pubdate,
       };
     })
     .catch(() => {

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -73,33 +73,25 @@ export const search = async (
   return { items: bookList, meta };
 };
 
-const searchByIsbn = async (isbn: string) => {
+const getInfoInNationalLibrary = async (isbn: string) => {
   let book;
+  let searchResult;
+  const key = '19b9689292b566b4a70bb5803ba42203b8e3151d03770428ecf1934feafefc89';
   await axios
-    .get(
-      `
-  https://openapi.naver.com/v1/search/book_adv?d_isbn=${isbn}`,
-      {
-        headers: {
-          'X-Naver-Client-Id': `${process.env.NAVER_BOOK_SEARCH_CLIENT_ID}`,
-          'X-Naver-Client-Secret': `${process.env.NAVER_BOOK_SEARCH_SECRET}`,
-        },
-      },
-    )
+    .get(`https://www.nl.go.kr/seoji/SearchApi.do?cert_key=${key}&result_style=json&page_no=1&page_size=10&isbn=${isbn}`)
     .then((res) => {
-      // eslint-disable-next-line prefer-destructuring
-      book = res.data.items[0];
-      book.isbn = book.isbn.split(' ')[1];
-      book.image = `https://image.kyobobook.co.kr/images/book/xlarge/${book.isbn.slice(-3)}/x${book.isbn}.jpg`;
-      delete book.price;
-      delete book.discount;
-      delete book.link;
-      delete book.description;
+      searchResult = res.data.docs[0];
+      const {
+        TITLE: title, TITLE_URL: image, AUTHOR: author, SUBJECT: category,
+      } = searchResult;
+      book = {
+        title, image, author, category, isbn,
+      };
     })
     .catch(() => {
       throw new Error(errorCode.ISBN_SEARCH_FAILED);
     });
-  return ([book]);
+  return (book);
 };
 
 export const createBook = async (book: types.CreateBookInfo) => {
@@ -148,80 +140,8 @@ export const createBook = async (book: types.CreateBookInfo) => {
 };
 
 export const createBookInfo = async (isbn: string) => {
-  const isbnInBookInfo = (await executeQuery(
-    `
-    SELECT
-      book.id AS id,
-      book.callSign AS callSign,
-      book_info.title AS title,
-      book_info.author AS author,
-      book_info.publisher AS publisher,
-      book_info.isbn AS isbn,
-      book_info.publishedAt AS pubdate,
-      (
-        SELECT name
-        FROM category
-        WHERE id = book_info.categoryId
-      ) AS category    
-    FROM book_info, book 
-    WHERE book_info.id = book.infoId AND isbn = ?
-  `,
-    [isbn],
-  )) as StringRows[];
-  const isbnInNaver: any = await searchByIsbn(isbn);
-  const sameTitleOrAuthor = await executeQuery(
-    `
-    SELECT
-      book.id AS id,
-      book.callSign AS callSign,
-      book_info.title AS title,
-      book_info.author AS author,
-      book_info.publisher AS publisher,
-      book_info.isbn AS isbn,
-      book_info.publishedAt AS pubdate,
-      (
-        SELECT name
-        FROM category
-        WHERE id = book_info.categoryId
-      ) AS category
-    FROM book_info, book 
-    WHERE book_info.id = book.infoId AND
-    ( book_info.title like ? OR book_info.author like ?)
-  `,
-    [`%${isbnInNaver[0].title}%`, `%${isbnInNaver[0].author}%`],
-  );
-  return { isbnInNaver, isbnInBookInfo, sameTitleOrAuthor };
-};
-
-export const deleteBook = async (book: models.Book): Promise<boolean> => {
-  const result = (await executeQuery(
-    `
-    SELECT *
-    FROM book
-    WHERE callSign = ?
-  `,
-    [book.callSign],
-  )) as models.BookEach[];
-  if (result.length === 0) {
-    return false;
-  }
-  await executeQuery(
-    `
-    DELETE FROM book
-    WHERE callSign = ?
-  `,
-    [book.callSign],
-  );
-  if (result.length === 1) {
-    await executeQuery(
-      `
-      DELETE FROM book_info
-      WHERE id = ?
-    `,
-      [result[0].infoId],
-    );
-  }
-  return true;
+  const bookInfo: any = await getInfoInNationalLibrary(isbn);
+  return { bookInfo };
 };
 
 export const sortInfo = async (

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -76,9 +76,8 @@ export const search = async (
 const getInfoInNationalLibrary = async (isbn: string) => {
   let book;
   let searchResult;
-  const key = '19b9689292b566b4a70bb5803ba42203b8e3151d03770428ecf1934feafefc89';
   await axios
-    .get(`https://www.nl.go.kr/seoji/SearchApi.do?cert_key=${key}&result_style=json&page_no=1&page_size=10&isbn=${isbn}`)
+    .get(`https://www.nl.go.kr/seoji/SearchApi.do?cert_key=${process.env.NATION_LIBRARY_KEY}&result_style=json&page_no=1&page_size=10&isbn=${isbn}`)
     .then((res) => {
       searchResult = res.data.docs[0];
       const {

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -486,27 +486,35 @@ router
    *              properties:
    *                title:
    *                  type: string
+   *                  nullable: false
    *                  example: "작별인사 (김영하 장편소설)"
    *                isbn:
    *                  type: string
+   *                  nullable: false
    *                  example: 9788065960874
    *                author:
    *                  type: string
+   *                  nullable: false
    *                  example: "김영하"
    *                publisher:
    *                  type: string
+   *                  nullable: false
    *                  example: "복복서가"
    *                image:
    *                  type: string
+   *                  nullable: false
    *                  example: "https://bookthumb-phinf.pstatic.net/cover/223/538/22353804.jpg?type=m1&udate=20220608"
    *                categoryId:
    *                  type: integer
+   *                  nullable: false
    *                  example: 1
    *                pubdate:
    *                  type: string
+   *                  nullable: false
    *                  example: "20220502"
    *                donator:
    *                  type: string
+   *                  nullable: true
    *                  example: seongyle
    *      responses:
    *         '200':
@@ -514,25 +522,9 @@ router
    *            content:
    *             application/json:
    *               schema:
-   *                 type: string
-   *                 description: insert success
-   *                 example: { code: 200, message: 'DB에 insert 성공하였습니다.' }
-   *         '400_case1':
-   *            description: 클라이언트 오류.
-   *            content:
-   *             application/json:
-   *              schema:
-   *                type: json
-   *                description: error decription
-   *                example: { errorCode: 300 }
-   *         '400_case2':
-   *            description: callsign 형식이 유효하지 않습니다.
-   *            content:
-   *             application/json:
-   *               schema:
    *                 type: json
-   *                 description: callsign 형식이 유효하지 않습니다.
-   *                 example: { errorCode: 306 }
+   *                 description: 성공했을 때 삽인된 callsign 값을 반환합니다.
+   *                 example: { callsign: 'c11.v1.c2' }
    *         '400_case3':
    *            description: naver open API에서 ISBN 검색결과가 없음.
    *            content:
@@ -540,14 +532,6 @@ router
    *               schema:
    *                 type: json
    *                 description: naver open API에서 ISBN 검색결과가 없음.
-   *                 example: { errorCode: 302 }
-   *         '400_case4':
-   *            description: naver openapi에서 못 찾음
-   *            content:
-   *             application/json:
-   *               schema:
-   *                 type: json
-   *                 description: naver open API에서 ISBN 검색 자체 실패
    *                 example: { errorCode: 302 }
    */
   .post('/create', authValidate(roleSet.librarian), createBook);
@@ -575,6 +559,7 @@ router
    *             application/json:
    *               schema:
    *                 type: JSON
+   *                 nullable: false
    *                 description: 국립중앙도서관에서 가지고 온 데이터를 보여줌. category는 십진분류의 대분류
    *                 example: {"bookInfo": {  "title": "작별인사",  "image": "https://www.nl.go.kr/seoji/fu/ecip/dbfiles/CIP_FILES_TBL/2022/04/07/9791191114225.jpg",  "author": "지은이: 김영하",  "category": "8", "publisher": "복복서가", "pubdate": "20220502"}}
    *

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -508,9 +508,6 @@ router
    *                donator:
    *                  type: string
    *                  example: seongyle
-   *                callSign:
-   *                  type: string
-   *                  example: e7.79.v2.c3
    *      responses:
    *         '200':
    *            description: 책 정보 정상적으로 insert됨.
@@ -572,38 +569,14 @@ router
    *          type: string
    *          example: 9791191114225
    *      responses:
-   *         '200_case1':
-   *            description: 네이버 ISBN 검색결과도 없고, 집현전 DB에도 비슷한게 없다.
-   *            content:
-   *             application/json:
-   *               schema:
-   *                 type: string
-   *                 description: 네이버 ISBN 검색결과가 없고, 집현전 DB에도 없을 때
-   *                 example: { "isbnInNaver": [], "isbnInBookInfo": [], "sameTitleOrAuthor": [] }
-   *         '200_case2':
-   *            description: 네이버 ISBN 검색결과있고, 집현전 DB에도 비슷한게 없다.
-   *            content:
-   *             application/json:
-   *               schema:
-   *                 type: string
-   *                 description: 네이버 ISBN 검색결과가 있고, 집현전 DB에도 없을 때
-   *                 example: {"isbnInNaver": [{"title": "작별인사 (김영하 장편소설)","link": "http://book.naver.com/bookdb/book_detail.php?bid=22353804","image": "https://bookthumb-phinf.pstatic.net/cover/223/538/22353804.jpg?type=m1&udate=20220608","author": "김영하","price": "14000","discount": "12600","publisher": "복복서가","pubdate": "20220502","isbn": "1191114228 9791191114225","description": "누구도 도와줄 수 없는 상황, 혼자 헤쳐나가야 한다\n지켜야 할 약속, 붙잡고 싶은 온기\n\n김영하가 『살인자의 기억법』 이후 9 년 만에 내놓는 장편소설 『작별인사』는 그리 멀지 않은 미래를 배경으로, 별안간 삶이 송두리째 뒤흔들린 한 소년의 여정을 좇는다. 유명한 IT 기업의 연구원인 아버지와 쾌적하고... " }], "isbnInBookInfo": [], "sameTitleOrAuthor": []}
-   *         '200_case3':
-   *            description: 네이버 ISBN 검색결과있고, 집현전 DB에 일치하는 ISBN이 있다.
+   *         '200':
+   *            description: 국립중앙도서관에서 ISBN으로 검색한뒤에 책정보를 반환
    *            content:
    *             application/json:
    *               schema:
    *                 type: JSON
-   *                 description: 네이버 ISBN 검색결과있고, 집현전 DB에 일치하는 ISBN이 있다
-   *                 example: {"isbnInNaver": [ {"title": "모두의 알고리즘 with 파이썬 (컴퓨팅 사고를 위한 기초 알고리즘)","link": "http://book.naver.com/bookdb/book_detail.php?bid=12057147","image": "https://bookthumb-phinf.pstatic.net/cover/120/571/12057147.jpg?type=m1&udate=20210508","author": "이승찬","price": "16000","discount": "14400","publisher": "길벗","pubdate": "20170518","isbn": "1160501726 9791160501728","description": "남녀노소 누구나 즐겁게 프로그래밍을 시작하세요!\n남녀노소 누구나 즐겁게 프로그래밍을 시작하세요!\n4차 산업혁명이 가져올 일자리와 삶의 변화 그 중심에 있는 알고리즘을 배워 보자! 인공지능이 일자리를 대체하는 시대가 되면서, 코딩 교육과 컴퓨팅 사고의 중요성이 나날이 커지고 있다. 그리고 그... "}], "isbnInBookInfo": [ {"callSign": "I9.17.v1.c1","title": "모두의 알고리즘 with 파이썬","author": "이승찬","publisher": "길벗","pubdate": "2017-05-17T15:00:00.000Z","isbn": "9791160501728","category": "자료구조/알고리즘"}, {"callSign": "I9.17.v1.c2","title": "모두의 알고리즘 with 파이썬","author": "이승찬","publisher": "길벗","pubdate": "2017-05-17T15:00:00.000Z","isbn": "9791160501728","category": "자료구조/알고리즘" }], "sameTitleOrAuthor": [ {"id": 180, "callSign": "I9.17.v1.c1","title": "모두의 알고리즘 with 파이썬", "author": "이승찬", "publisher": "길벗", "isbn": "9791160501728","category": "자료구조/알고리즘"},{"id": 181,"callSign": "I9.17.v1.c2","title": "모두의 알고리즘 with 파이썬","author": "이승찬","publisher": "길벗","isbn": "9791160501728","category": "자료구조/알고리즘"}]}
-   *         '200_case4':
-   *            description: 네이버 ISBN 검색결과있고, 집현전 DB에 ISBN가 같은게 없고, (같은 저자의 책 or 같은 제목의 책)이 있을 때
-   *            content:
-   *             application/json:
-   *               schema:
-   *                 type: JSON
-   *                 description: 네이버 ISBN 검색결과가 없고, 집현전 DB에도 없을 때
-   *                 example: {"isbnInNaver": [ { "title": "모두의 파이썬 (20일 만에 배우는 프로그래밍 기초)", "link": "http://book.naver.com/bookdb/book_detail.php?bid=10541921",  "image": "https://bookthumb-phinf.pstatic.net/cover/105/419/10541921.jpg?type=m1&udate=20181102", "author": "이승찬", "price": "12000", "discount": "", "publisher": "길벗", "pubdate": "20160509", "isbn": "1186978899 9791186978894", "description": "즐겁게 시작하는 나의 첫 프로그래밍!\n\n프로그래밍을 한 번도 해본 적이 없어도 괜찮다. 파이썬이 무엇인지 몰라도 상관 없다. 《모두의 파이썬》은 어려운 개념과 복잡한 이론 설명은 최대한 줄이고, 초보자가 프로그래밍을 쉽게 배울 수 있도록 짧고 간단한 예제로 내용을 구성했다. \n\n처음부터 모든 것을 다... " }  ], "isbnInBookInfo": [], "sameTitleOrAuthor": [ { "id": 180,"callSign": "I9.17.v1.c1", "title": "모두의 알고리즘 with 파이썬", "author": "이승찬", "publisher": "길벗", "isbn": "9791160501728", "category": "자료구조/알고리즘" }, {"id": 181, "callSign": "I9.17.v1.c2", "title": "모두의 알고리즘 with 파이썬", "author": "이승찬", "publisher": "길벗", "isbn": "9791160501728", "category": "자료구조/알고리즘"}]}
+   *                 description: 국립중앙도서관에서 가지고 온 데이터를 보여줌. category는 십진분류의 대분류
+   *                 example: {"bookInfo": {  "title": "작별인사",  "image": "https://www.nl.go.kr/seoji/fu/ecip/dbfiles/CIP_FILES_TBL/2022/04/07/9791191114225.jpg",  "author": "지은이: 김영하",  "category": "8"}}
    *
    */
   .get('/create', authValidate(roleSet.librarian), createBookInfo);

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -576,7 +576,7 @@ router
    *               schema:
    *                 type: JSON
    *                 description: 국립중앙도서관에서 가지고 온 데이터를 보여줌. category는 십진분류의 대분류
-   *                 example: {"bookInfo": {  "title": "작별인사",  "image": "https://www.nl.go.kr/seoji/fu/ecip/dbfiles/CIP_FILES_TBL/2022/04/07/9791191114225.jpg",  "author": "지은이: 김영하",  "category": "8"}}
+   *                 example: {"bookInfo": {  "title": "작별인사",  "image": "https://www.nl.go.kr/seoji/fu/ecip/dbfiles/CIP_FILES_TBL/2022/04/07/9791191114225.jpg",  "author": "지은이: 김영하",  "category": "8", "publisher": "복복서가", "pubdate": "20220502"}}
    *
    */
   .get('/create', authValidate(roleSet.librarian), createBookInfo);


### PR DESCRIPTION
### 개요
JIP 235 get books/create 국립중앙도서관 분류기준 정보 추가

### 작업 사항
- [X]  카테고리 대분류 추가
- [X] post books/create 스웨거 변경
- [X]  get books/create에 반환값 변경
- [X] git secrete에 국립중앙도서관 키값 분리 및 build할 때 환경변수에 들어가게

### 우려 사항
 저자를 보내주는게 "지은이 : 김영하" 이런식으로 보내줌...

### 목적
도서등록 페이지에서 비개발도서일 때 카테고리를 추천해줌. 