### PR TITLE
Jip 359 callsign 자동 삽입

### DIFF
--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -14,9 +14,9 @@ export const createBook = async (
   next: NextFunction,
 ) => {
   const {
-    title, author, categoryId, callSign, pubdate,
+    title, author, categoryId, pubdate,
   } = req.body;
-  if (!(title && author && categoryId && callSign && pubdate)) {
+  if (!(title && author && categoryId && pubdate)) {
     return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
   }
   try {

--- a/backend/src/books/books.type.ts
+++ b/backend/src/books/books.type.ts
@@ -20,5 +20,4 @@ export interface CreateBookInfo {
   categoryId?: string;
   pubdate?: string | Date;
   donator: string;
-  callSign: string;
 }

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -505,7 +505,7 @@ router
    *                  nullable: false
    *                  example: "https://bookthumb-phinf.pstatic.net/cover/223/538/22353804.jpg?type=m1&udate=20220608"
    *                categoryId:
-   *                  type: integer
+   *                  type: string
    *                  nullable: false
    *                  example: 1
    *                pubdate:

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -525,14 +525,6 @@ router
    *                 type: json
    *                 description: 성공했을 때 삽인된 callsign 값을 반환합니다.
    *                 example: { callsign: 'c11.v1.c2' }
-   *         '400_case3':
-   *            description: naver open API에서 ISBN 검색결과가 없음.
-   *            content:
-   *             application/json:
-   *               schema:
-   *                 type: json
-   *                 description: naver open API에서 ISBN 검색결과가 없음.
-   *                 example: { errorCode: 302 }
    */
   .post('/create', authValidate(roleSet.librarian), createBook);
 


### PR DESCRIPTION
### 개요
 책등록시 callsign 자동삽입

### 유의 사항
 pubdate가 "20220510" 같은 형식으로 들어온다는 가정하에 코드가 작동함. 
 get create/books 에서 보내주는 값는 위와 같은 형식이긴 함.

### 작업 사항
 1. 기존 책이 없을 때 책 등록
  카데고리알파벳 = 카테고리 아이디를 기준으로 찾아줌
  주번호 = 기존 카테고리에 있던 책들의 주번호 + 1
  카피번호 = 1
 2. 기존 책이 있을 때 책 등록
  카테고리알파벳 = 기존 책의 카테고리를 가지고 옴
  주번호 = 기존 책의 주번호
  카피번호 = 기존 책의 카피번호중 최대값 + 1


### 우려 사항
   기존 책이 있을 떄 책 등록 상황에서 
    청구기호에서는 기존 책의 카테고리를 최우선함.  -> 사용자가 카테고리를 잘못 입력한다면 디비에 들어간 카데고리와 청구기호 카테고리가 다를 우려..
    
대안, 카테고리알파벳은 무조건 카테고리아이디로 찾아줌. 
대안의 문제 : 기존 책과 카테고리알파벳이 달라질 수도 있음.
  
   
### 스크린샷 (optional)
ISBN이 없는 책이 들어갈 때
![image](https://user-images.githubusercontent.com/62806979/182710043-bace5a95-a5dc-488b-bcc6-8808c5f4a08a.png)

ISBN이 있는 책이 들어갈 때
![image](https://user-images.githubusercontent.com/62806979/182710327-ccefbcb2-fd10-42a5-8245-7bd0036196f7.png)
