### PR TITLE
JIP 360 도서등록 피드백 반영

### DIFF
--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -8,6 +8,14 @@ import { logger } from '../utils/logger';
 import * as BooksService from './books.service';
 import * as types from './books.type';
 
+const pubdateFormatValidator = (pubdate : string) => {
+  const regexConditon = (/^[0-9]{8}$/);
+  if (regexConditon.test(pubdate) === false) {
+    return false;
+  }
+  return true;
+};
+
 export const createBook = async (
   req: Request,
   res: Response,
@@ -18,6 +26,9 @@ export const createBook = async (
   } = req.body;
   if (!(title && author && categoryId && pubdate)) {
     return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
+  }
+  if (pubdateFormatValidator(pubdate) === false) {
+    return next(new ErrorResponse(errorCode.INVALID_PUBDATE_FORNAT, status.BAD_REQUEST));
   }
   try {
     return res

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -82,8 +82,9 @@ const getInfoInNationalLibrary = async (isbn: string) => {
       searchResult = res.data.docs[0];
       const {
         // eslint-disable-next-line max-len
-        TITLE: title, TITLE_URL: image, AUTHOR: author, SUBJECT: category, PUBLISHER: publisher, PUBLISH_PREDATE: pubdate,
+        TITLE: title, AUTHOR: author, SUBJECT: category, PUBLISHER: publisher, PUBLISH_PREDATE: pubdate,
       } = searchResult;
+      const image = `https://image.kyobobook.co.kr/images/book/xlarge/${isbn.slice(-3)}/x${isbn}.jpg`;
       book = {
         title, image, author, category, isbn, publisher, pubdate,
       };

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -118,6 +118,69 @@ const getAuthorInNaver = async (isbn: string) => {
   return (author);
 };
 
+const getCategoryAlpabet = (categoryId : number) => {
+  switch (categoryId) {
+    case 1:
+      return 'K';
+    case 2:
+      return 'C';
+    case 3:
+      return 'O';
+    case 4:
+      return 'A';
+    case 5:
+      return 'I';
+    case 6:
+      return 'G';
+    case 7:
+      return 'J';
+    case 8:
+      return 'c';
+    case 9:
+      return 'F';
+    case 10:
+      return 'E';
+    case 11:
+      return 'e';
+    case 12:
+      return 'H';
+    case 13:
+      return 'd';
+    case 14:
+      return 'D';
+    case 15:
+      return 'k';
+    case 16:
+      return 'c';
+    case 17:
+      return 'B';
+    case 18:
+      return 'e';
+    case 19:
+      return 'n';
+    case 20:
+      return 'N';
+    case 21:
+      return 'j';
+    case 22:
+      return 'a';
+    case 23:
+      return 'f';
+    case 24:
+      return 'L';
+    case 25:
+      return 'b';
+    case 26:
+      return 'M';
+    case 27:
+      return 'i';
+    case 28:
+      return 'l';
+    default:
+      throw new Error(errorCode.INVALID_CATEGORY_ID);
+  }
+};
+
 export const createBook = async (book: types.CreateBookInfo) => {
   const conn = await pool.getConnection();
   const transactionExecuteQuery = makeExecuteQuery(conn);
@@ -134,68 +197,6 @@ export const createBook = async (book: types.CreateBookInfo) => {
     }
 
     const category = (await transactionExecuteQuery(`SELECT name FROM category WHERE id = ${book.categoryId}`))[0].name;
-    const getCategoryAlpabet = (categoryId : number) => {
-      switch (categoryId) {
-        case 1:
-          return 'K';
-        case 2:
-          return 'C';
-        case 3:
-          return 'O';
-        case 4:
-          return 'A';
-        case 5:
-          return 'I';
-        case 6:
-          return 'G';
-        case 7:
-          return 'J';
-        case 8:
-          return 'c';
-        case 9:
-          return 'F';
-        case 10:
-          return 'E';
-        case 11:
-          return 'e';
-        case 12:
-          return 'H';
-        case 13:
-          return 'd';
-        case 14:
-          return 'D';
-        case 15:
-          return 'k';
-        case 16:
-          return 'c';
-        case 17:
-          return 'B';
-        case 18:
-          return 'e';
-        case 19:
-          return 'n';
-        case 20:
-          return 'N';
-        case 21:
-          return 'j';
-        case 22:
-          return 'a';
-        case 23:
-          return 'f';
-        case 24:
-          return 'L';
-        case 25:
-          return 'b';
-        case 26:
-          return 'M';
-        case 27:
-          return 'i';
-        case 28:
-          return 'l';
-        default:
-          throw new Error(errorCode.INVALID_CATEGORY_ID);
-      }
-    };
 
     if (isbnInBookInfo[0].cnt === 0) {
       await transactionExecuteQuery(
@@ -223,7 +224,7 @@ export const createBook = async (book: types.CreateBookInfo) => {
       recommendCopyNum = (await transactionExecuteQuery('SELECT MAX(convert(substring(substring_index(callsign, ".", -1),2), unsigned)) + 1 as recommendCopyNum FROM book WHERE infoId = (select id from book_info where isbn = ?)', [book.isbn]))[0].recommendCopyNum;
     }
     const recommendCallSign = `${categoryAlpabet}${recommendPrimaryNum}.${String(book.pubdate).slice(2, 4)}.v1.c${recommendCopyNum}`;
-    await executeQuery(`INSERT INTO book(donator,donatorId,callSign,status,infoId) VALUES
+    await transactionExecuteQuery(`INSERT INTO book(donator,donatorId,callSign,status,infoId) VALUES
     (?,(SELECT id FROM user WHERE nickname = ? ORDER BY createdAt DESC LIMIT 1),?,0,(SELECT id FROM book_info WHERE (isbn = ? or title = ?) ORDER BY createdAt DESC LIMIT 1))
   `, [book.donator, book.donator, recommendCallSign, book.isbn, book.title]);
     return ({ callsign: recommendCallSign });

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -81,12 +81,11 @@ const getInfoInNationalLibrary = async (isbn: string) => {
     .then((res) => {
       searchResult = res.data.docs[0];
       const {
-        // eslint-disable-next-line max-len
-        TITLE: title, AUTHOR: author, SUBJECT: category, PUBLISHER: publisher, PUBLISH_PREDATE: pubdate,
+        TITLE: title, SUBJECT: category, PUBLISHER: publisher, PUBLISH_PREDATE: pubdate,
       } = searchResult;
       const image = `https://image.kyobobook.co.kr/images/book/xlarge/${isbn.slice(-3)}/x${isbn}.jpg`;
       book = {
-        title, image, author, category, isbn, publisher, pubdate,
+        title, image, category, isbn, publisher, pubdate,
       };
     })
     .catch(() => {

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -95,6 +95,29 @@ const getInfoInNationalLibrary = async (isbn: string) => {
   return (book);
 };
 
+const getAuthorInNaver = async (isbn: string) => {
+  let author;
+  await axios
+    .get(
+      `
+  https://openapi.naver.com/v1/search/book_adv?d_isbn=${isbn}`,
+      {
+        headers: {
+          'X-Naver-Client-Id': `${process.env.NAVER_BOOK_SEARCH_CLIENT_ID}`,
+          'X-Naver-Client-Secret': `${process.env.NAVER_BOOK_SEARCH_SECRET}`,
+        },
+      },
+    )
+    .then((res) => {
+      // eslint-disable-next-line prefer-destructuring
+      author = res.data.items[0].author;
+    })
+    .catch(() => {
+      throw new Error(errorCode.ISBN_SEARCH_FAILED_IN_NAVER);
+    });
+  return (author);
+};
+
 export const createBook = async (book: types.CreateBookInfo) => {
   const conn = await pool.getConnection();
   const transactionExecuteQuery = makeExecuteQuery(conn);
@@ -217,6 +240,7 @@ export const createBook = async (book: types.CreateBookInfo) => {
 
 export const createBookInfo = async (isbn: string) => {
   const bookInfo: any = await getInfoInNationalLibrary(isbn);
+  bookInfo.author = await getAuthorInNaver(isbn);
   return { bookInfo };
 };
 

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -597,6 +597,7 @@ router
    *                        example: "9791191114225"
    *                      publisher:
    *                        description: 출판사
+   *                        nullable: false
    *                        type: string
    *                        example: "복복서가"
    *                      pubdate:

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -524,7 +524,7 @@ router
    *               schema:
    *                 type: json
    *                 description: 성공했을 때 삽인된 callsign 값을 반환합니다.
-   *                 example: { callsign: 'c11.v1.c2' }
+   *                 example: { callsign: 'c11.22.v1.c2' }
    */
   .post('/create', authValidate(roleSet.librarian), createBook);
 

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -533,7 +533,7 @@ router
    *                    type: json
    *                    example : { errorCode: 308 }
    *         '실패 케이스 2':
-   *              description: 보내줌 카테고리 ID에 해당하는 callsign을 찾을 수 없음
+   *              description: 보내준 카테고리 ID에 해당하는 callsign을 찾을 수 없음
    *              content:
    *                application/json:
    *                  schema:
@@ -605,6 +605,20 @@ router
    *                        type: string
    *                        format: date
    *                        example: "20220502"
+   *        '실패 케이스 1':
+   *            description: 국립중앙 도서관 API에서 ISBN 검색이 실패
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  type: json
+   *                  example: { errorCode : 303 }
+   *        '실패 케이스 2':
+   *            description: 네이버 책검색 API에서 ISBN 검색이 실패
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  type: json
+   *                  example: { errorCode : 310 }
    */
   .get('/create', authValidate(roleSet.librarian), createBookInfo);
 

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -490,7 +490,7 @@ router
    *                  example: "작별인사 (김영하 장편소설)"
    *                isbn:
    *                  type: string
-   *                  nullable: false
+   *                  nullable: true
    *                  example: 9788065960874
    *                author:
    *                  type: string
@@ -502,7 +502,7 @@ router
    *                  example: "복복서가"
    *                image:
    *                  type: string
-   *                  nullable: false
+   *                  nullable: true
    *                  example: "https://bookthumb-phinf.pstatic.net/cover/223/538/22353804.jpg?type=m1&udate=20220608"
    *                categoryId:
    *                  type: string

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -525,6 +525,20 @@ router
    *                 type: json
    *                 description: 성공했을 때 삽인된 callsign 값을 반환합니다.
    *                 example: { callsign: 'c11.22.v1.c2' }
+   *         '실패 케이스 1':
+   *              description: 예상치 못한 에러로 책 정보 insert에 실패함.
+   *              content:
+   *                application/json:
+   *                  schema:
+   *                    type: json
+   *                    example : { errorCode: 308 }
+   *         '실패 케이스 2':
+   *              description: 보내줌 카테고리 ID에 해당하는 callsign을 찾을 수 없음
+   *              content:
+   *                application/json:
+   *                  schema:
+   *                    type: json
+   *                    example : { errorCode: 309 }
    */
   .post('/create', authValidate(roleSet.librarian), createBook);
 
@@ -545,16 +559,52 @@ router
    *          type: string
    *          example: 9791191114225
    *      responses:
-   *         '200':
-   *            description: 국립중앙도서관에서 ISBN으로 검색한뒤에 책정보를 반환
-   *            content:
-   *             application/json:
-   *               schema:
-   *                 type: JSON
-   *                 nullable: false
-   *                 description: 국립중앙도서관에서 가지고 온 데이터를 보여줌. category는 십진분류의 대분류
-   *                 example: {"bookInfo": {  "title": "작별인사",  "image": "https://www.nl.go.kr/seoji/fu/ecip/dbfiles/CIP_FILES_TBL/2022/04/07/9791191114225.jpg",  "author": "지은이: 김영하",  "category": "8", "publisher": "복복서가", "pubdate": "20220502"}}
-   *
+   *        '200':
+   *          description: 국립중앙도서관에서 ISBN으로 검색한뒤에 책정보를 반환
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                description: ISBN으로 국립중앙도서관에서 검색후에 정보를 반환, 이미지는 교보문고에서 가지고 옴
+   *                properties:
+   *                  bookInfo:
+   *                    type: object
+   *                    properties:
+   *                      title:
+   *                        description: 책의 제목
+   *                        nullable: false
+   *                        type: string
+   *                        example: "작별인사"
+   *                      image:
+   *                        description: 책 표지 이미지 주소
+   *                        nullable: true
+   *                        type: string
+   *                        example: "http://image.kyobobook.co.kr/images/book/xlarge/225/x9791191114225.jpg"
+   *                      author:
+   *                        description: 저자
+   *                        nullable: false
+   *                        type: string
+   *                        example: "지은이: 김영하"
+   *                      category:
+   *                        description: 십진분류법상 대분류
+   *                        nullable: true
+   *                        type: string
+   *                        example: "8"
+   *                      isbn:
+   *                        description: ISBN 번호
+   *                        nullable: false
+   *                        type: string
+   *                        example: "9791191114225"
+   *                      publisher:
+   *                        description: 출판사
+   *                        type: string
+   *                        example: "복복서가"
+   *                      pubdate:
+   *                        description: 출판일자
+   *                        nullable: false
+   *                        type: string
+   *                        format: date
+   *                        example: "20220502"
    */
   .get('/create', authValidate(roleSet.librarian), createBookInfo);
 

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -539,6 +539,13 @@ router
    *                  schema:
    *                    type: json
    *                    example : { errorCode: 309 }
+   *         '실패 케이스 3':
+   *              description: 입력한 pubdate가 알맞은 형식이 아님. 기대하는 형식 "20220807"
+   *              content:
+   *                application/json:
+   *                  schema:
+   *                    type: json
+   *                    example : { errorCode: 311 }
    */
   .post('/create', authValidate(roleSet.librarian), createBook);
 

--- a/backend/src/utils/error/errorCode.ts
+++ b/backend/src/utils/error/errorCode.ts
@@ -31,6 +31,7 @@ export const INVALID_CALL_SIGN = '306';
 export const NO_BOOK_ID = '307';
 export const FAIL_CREATE_BOOK_BY_UNEXPECTED = '308';
 export const INVALID_CATEGORY_ID = '309';
+export const ISBN_SEARCH_FAILED_IN_NAVER = '310';
 
 export const NO_USER_ID = '401';
 export const NO_PERMISSION = '402';

--- a/backend/src/utils/error/errorCode.ts
+++ b/backend/src/utils/error/errorCode.ts
@@ -29,6 +29,7 @@ export const NO_BOOK_INFO_ID = '304';
 export const CALL_SIGN_OVERLAP = '305';
 export const INVALID_CALL_SIGN = '306';
 export const NO_BOOK_ID = '307';
+export const FAIL_CREATE_BOOK = '308';
 
 export const NO_USER_ID = '401';
 export const NO_PERMISSION = '402';

--- a/backend/src/utils/error/errorCode.ts
+++ b/backend/src/utils/error/errorCode.ts
@@ -32,6 +32,7 @@ export const NO_BOOK_ID = '307';
 export const FAIL_CREATE_BOOK_BY_UNEXPECTED = '308';
 export const INVALID_CATEGORY_ID = '309';
 export const ISBN_SEARCH_FAILED_IN_NAVER = '310';
+export const INVALID_PUBDATE_FORNAT = '311';
 
 export const NO_USER_ID = '401';
 export const NO_PERMISSION = '402';

--- a/backend/src/utils/error/errorCode.ts
+++ b/backend/src/utils/error/errorCode.ts
@@ -29,7 +29,8 @@ export const NO_BOOK_INFO_ID = '304';
 export const CALL_SIGN_OVERLAP = '305';
 export const INVALID_CALL_SIGN = '306';
 export const NO_BOOK_ID = '307';
-export const FAIL_CREATE_BOOK = '308';
+export const FAIL_CREATE_BOOK_BY_UNEXPECTED = '308';
+export const INVALID_CATEGORY_ID = '309';
 
 export const NO_USER_ID = '401';
 export const NO_PERMISSION = '402';

--- a/database/00_create_table.sql
+++ b/database/00_create_table.sql
@@ -24,7 +24,7 @@ DROP TABLE IF EXISTS `book`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `book` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `donator` varchar(255) NOT NULL,
+  `donator` varchar(255) DEFAULT NULL,
   `callSign` varchar(255) BINARY NOT NULL UNIQUE,
   `status` int NOT NULL,
   `createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),


### PR DESCRIPTION
### 개요
도서등록 피드백 반영

### 작업 사항
- [X] 국립중앙도서관 API에서 개발관련 책들은 이미지를 안 보내주는 경우가 많아 교보문고 이미지로 변경
- [X] post books/create에서 image와 isbn는 nullable임
- [x] 이미 있는 책에 대한 callsign을 결정할 때, 사용자를 믿지 않음, -> 사용자가 입력한 카테고리 무시 (기존 코드에서 되어 있었음)
- [x] 상세한 에러처리 필요
    카테고리ID가 유효하지 않을 때 에러코드 309 반환,
    도서 등록이 실패 했을 때 에러코드 308 반환
- [x] 책 등록 로직 하나의 트랙잭션으로 처리 필요, 실패시 롤백
- [X] 에러처리 스웨거에 추가
- [X] 국립중앙도서관 API에서 author을 반환 할 때, `저자: 김영하`, `지은이: 테스트`  `전진권 지음`,처럼 마음대로 반환함.. -> author는 네이버 책 검색 API에서 가지고 옴
- [x] pubdate 형식 체크하기
- [X] 하나의 트랙잭션으로 post books/create 처리할 떄 DB lock 문제 해결, (`conn.commit()`를 안해주고 있었음..)

### 스크린샷 (optional)
 동작 확인
 - 등록하는 책이 DB에 없을 때
     ![image](https://user-images.githubusercontent.com/62806979/183275424-a146fd96-d7ba-40ce-9c4d-07b057207d78.png)
-  등록하는 책이 DB에 있을 때
     ![image](https://user-images.githubusercontent.com/62806979/183275453-1d1fb543-cd1e-4b7f-bf44-81f242cc3905.png)
- isbn이 없을 때 
     ![image](https://user-images.githubusercontent.com/62806979/183276165-b37c1fd2-6835-43a9-90c6-f20ba015c03d.png)
- isbn이 빈 문자열일 때
     ![image](https://user-images.githubusercontent.com/62806979/183277835-0012236e-7e12-41e4-93ca-e19f40379dc8.png)
- donator가 없을 때
    ![image](https://user-images.githubusercontent.com/62806979/183277875-7964a5e1-12ab-4360-9710-31cb391b09a0.png)
- donator 빈 문자열일 때
    ![image](https://user-images.githubusercontent.com/62806979/183277767-c42e02e8-2492-4348-a483-62d2a9db2924.png)

### 기술 부채
 isbn, imgae, donator에 `NOTEXIST`라는 문자열이 들어오면 `NOTEXIST`로 값이 입력되는게 아니라, null이 입력됨