### PR TITLE
[fix] 이번달 인기도서 -> 42일간 인기도서

### DIFF
--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -262,6 +262,14 @@ export const sortInfo = async (
     default:
       ordering = 'ORDER BY book_info.createdAt DESC';
   }
+  let lendingCntCondition = '';
+  switch (sort) {
+    case 'popular':
+      lendingCntCondition = 'WHERE lending.createdAt >= date_sub(now(), interval 42 day)';
+      break;
+    default:
+      lendingCntCondition = '';
+  }
 
   const bookList = (await executeQuery(
     `
@@ -283,6 +291,7 @@ export const sortInfo = async (
       COUNT(lending.id) as lendingCnt
     FROM book_info LEFT JOIN lending
     ON book_info.id = (SELECT book.infoId FROM book WHERE lending.bookId = book.id LIMIT 1)
+    ${lendingCntCondition}
     GROUP BY book_info.id
     ${ordering}
     LIMIT ?;

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -265,7 +265,7 @@ export const sortInfo = async (
   let lendingCntCondition = '';
   switch (sort) {
     case 'popular':
-      lendingCntCondition = 'WHERE lending.createdAt >= date_sub(now(), interval 42 day)';
+      lendingCntCondition = 'and lending.createdAt >= date_sub(now(), interval 42 day)';
       break;
     default:
       lendingCntCondition = '';

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -165,7 +165,7 @@ router
    * @openapi
    * /api/books/info:
    *    get:
-   *      description: 책 정보를 기준에 따라 정렬한다.
+   *      description: 책 정보를 기준에 따라 정렬한다. 정렬기준이 popular일 경우 당일으로부터 42일간 인기순으로 한다.
    *      tags:
    *      - books
    *      parameters:


### PR DESCRIPTION
### 개요
이번달 인기도서 -> 42일간 인기도서

### 작업 사항
- 스웨거 수정
- 42일간 대출기록으로 인기도서 선정

### 변경점
- sql문 수정

### 목적
- 홈페이지내에 조금 더 의미있는 정보 전달

### FYI
 where 는 조인 연산전에 수행!
 on 는 조인 연산후에 수행!

