### PR TITLE
FEAT: 도서수정 API 관련 사항

### DIFF
--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -9,9 +9,9 @@ import { logger } from '../utils/logger';
 import * as BooksService from './books.service';
 import * as types from './books.type';
 
-const pubdateFormatValidator = (pubdate : string) => {
+const pubdateFormatValidator = (pubdate : String | Date) => {
   const regexConditon = (/^[0-9]{8}$/);
-  if (regexConditon.test(pubdate) === false) {
+  if (regexConditon.test(String(pubdate)) === false) {
     return false;
   }
   return true;
@@ -351,15 +351,15 @@ export const updateBookInfo = async (
           bookInfo.categoryId || bookInfo.publishedAt || book.callSign || book.Status))
     return next(new ErrorResponse(errorCode.NO_BOOK_INFO_DATA, status.BAD_REQUEST));
 
-  // if (isNullish(bookInfo.title) == false) { bookInfo.title.trim(); }
-  // if (isNullish(bookInfo.author) == false) { bookInfo.author.trim(); }
-  // if (isNullish(bookInfo.publisher) == false) { bookInfo.publisher.trim(); }
-  // if (isNullish(bookInfo.image) == false) { bookInfo.image.trim(); }
-  // if (isNullish(bookInfo.publishedAt) == false && pubdateFormatValidator(bookInfo.publishedAt)) {
-  //   bookInfo.publishedAt.trim();
-  // } else if (pubdateFormatValidator(req.body.publishedAt) == false) {
-  //   return next(new ErrorResponse(errorCode.INVALID_PUBDATE_FORNAT, status.BAD_REQUEST));
-  // }
+  if (isNullish(bookInfo.title) == false) { bookInfo.title.trim(); }
+  if (isNullish(bookInfo.author) == false) { bookInfo.author.trim(); }
+  if (isNullish(bookInfo.publisher) == false) { bookInfo.publisher.trim(); }
+  if (isNullish(bookInfo.image) == false) { bookInfo.image.trim(); }
+  if (isNullish(bookInfo.publishedAt) == false && pubdateFormatValidator(bookInfo.publishedAt)) {
+    String(bookInfo.publishedAt).trim();
+  } else if (pubdateFormatValidator(req.body.publishedAt) == false) {
+    return next(new ErrorResponse(errorCode.INVALID_PUBDATE_FORNAT, status.BAD_REQUEST));
+  }
   if (isNullish(book.callSign) == false) { book.callSign.trim(); }
   if (bookStatusFormatValidator(book.Status) == false) {
     return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));

--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -17,6 +17,13 @@ const pubdateFormatValidator = (pubdate : string) => {
   return true;
 };
 
+const bookStatusFormatValidator = (bookStatus : number) => {
+  if (bookStatus < 0 || bookStatus > 2) {
+    return false;
+  }
+  return true;
+};
+
 export const createBook = async (
   req: Request,
   res: Response,
@@ -324,34 +331,41 @@ export const updateBookInfo = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const bookInfoId = parseInt(req.params.bookInfoId, 10);
-  if (bookInfoId <= 0 || bookInfoId === NaN)
-    return next (new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST))
-  let {
-    title,
-    author,
-    publisher,
-    isbn,
-    image,
-    categoryId,
-    publishedAt
-  } = req.body;
-  if (!(title || author || publisher || isbn || image || categoryId || publishedAt)) {
-    return next(new ErrorResponse(errorCode.NO_BOOK_INFO_DATA, status.BAD_REQUEST));
+  let bookInfo: types.UpdateBookInfo = {
+    id: req.body.bookInfoId,
+    title: req.body.title,
+    author: req.body.author,
+    publisher: req.body.publisher,
+    image: req.body.image,
+    publishedAt: req.body.publishedAt
   }
-  if (isNullish(title) == false) { req.body.title = title.trim(); }
-  if (isNullish(author) == false) { req.body.author = author.trim(); }
-  if (isNullish(publisher) == false) { req.body.publisher = publisher.trim(); }
-  if (isNullish(isbn) == false) { req.body.isbn = isbn.trim(); }
-  if (isNullish(image) == false) { req.body.image = image.trim(); }
-  if (isNullish(categoryId) == false) { req.body.categoryId = categoryId.trim(); }
-  if (isNullish(publishedAt) == false && pubdateFormatValidator(publishedAt)) {
-    req.body.publishedAt = publishedAt.trim();
-  } else if (pubdateFormatValidator(req.body.publishedAt) == false) {
-    return next(new ErrorResponse(errorCode.INVALID_PUBDATE_FORNAT, status.BAD_REQUEST));
+  let book: types.UpdateBook = {
+    id: req.body.bookId,
+    callSign: req.body.callSign,
+    Status: req.body.status,
+  }
+  
+  if (book.id <= 0 || book.id === NaN || bookInfo.id <= 0 || bookInfo.id === NaN )
+    return next (new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST))
+  if (!(bookInfo.title || bookInfo.author || bookInfo.publisher || bookInfo.image || 
+          bookInfo.categoryId || bookInfo.publishedAt || book.callSign || book.Status))
+    return next(new ErrorResponse(errorCode.NO_BOOK_INFO_DATA, status.BAD_REQUEST));
+
+  // if (isNullish(bookInfo.title) == false) { bookInfo.title.trim(); }
+  // if (isNullish(bookInfo.author) == false) { bookInfo.author.trim(); }
+  // if (isNullish(bookInfo.publisher) == false) { bookInfo.publisher.trim(); }
+  // if (isNullish(bookInfo.image) == false) { bookInfo.image.trim(); }
+  // if (isNullish(bookInfo.publishedAt) == false && pubdateFormatValidator(bookInfo.publishedAt)) {
+  //   bookInfo.publishedAt.trim();
+  // } else if (pubdateFormatValidator(req.body.publishedAt) == false) {
+  //   return next(new ErrorResponse(errorCode.INVALID_PUBDATE_FORNAT, status.BAD_REQUEST));
+  // }
+  if (isNullish(book.callSign) == false) { book.callSign.trim(); }
+  if (bookStatusFormatValidator(book.Status) == false) {
+    return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
   }
   try {
-    await BooksService.updateBookInfo(req.body, bookInfoId);
+    await BooksService.updateBookInfo(bookInfo, book, bookInfo.id, book.id);
     return res.status(status.NO_CONTENT).send()
   } catch (error: any) {
     const errorNumber = parseInt(error.message, 10);

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -589,9 +589,9 @@ export const updateBookInfo = async (bookInfo: types.UpdateBookInfo, book: types
   let updateBookString = '';
   const queryBookInfoParam = [];
   const queryBookParam = [];
-  var bookInfoObject: any = {
+  let bookInfoObject: any = {
   } = bookInfo
-  var bookObject: any = {
+  let bookObject: any = {
   } = book
 
   for (let key in bookInfoObject) {

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -584,26 +584,52 @@ export const getLikeInfo = async (userId: number, bookInfoId: number) => {
   return ({ "bookInfoId": 123, "isLiked" : false, "likeNum" : 15 });
 };
 
-export const updateBookInfo = async (book: types.UpdateBookInfo, bookInfoId: number) => {
-  let updateString = '';
-  const queryParam = [];
+export const updateBookInfo = async (bookInfo: types.UpdateBookInfo, book: types.UpdateBook, bookInfoId: number, bookId: number) => {
+  let updateBookInfoString = '';
+  let updateBookString = '';
+  const queryBookInfoParam = [];
+  const queryBookParam = [];
   var bookInfoObject: any = {
+  } = bookInfo
+  var bookObject: any = {
   } = book
 
   for (let key in bookInfoObject) {
     let value = bookInfoObject[key];
-    if (key !== '') {
-      updateString += `${key } = ?,`
-      queryParam.push(value)
+    if (key === 'id') {
+    } else if (key !== '') {
+      updateBookInfoString += `${key } = ?,`
+      queryBookInfoParam.push(value)
     } else if (key === null){
-      updateString += `${key} = NULL,`
+      updateBookInfoString += `${key} = NULL,`
     }
   }
-  updateString = updateString.slice(0,-1)
+
+  for (let key in bookObject) {
+    let value = bookObject[key];
+    if (key === 'id') {
+    } else if (key !== '') {
+      updateBookString += `${key } = ?,`
+      queryBookParam.push(value)
+    } else if (key === null){
+      updateBookString += `${key} = NULL,`
+    }
+  }
+
+  updateBookInfoString = updateBookInfoString.slice(0,-1)
+  updateBookString = updateBookString.slice(0,-1)
+
   await executeQuery(`
     UPDATE book_info 
     SET 
-    ${updateString} 
+    ${updateBookInfoString} 
     WHERE id = ${bookInfoId}
-    `, queryParam);
+    `, queryBookInfoParam);
+
+  await executeQuery(`
+    UPDATE book 
+    SET 
+    ${updateBookString} 
+    WHERE id = ${bookId} ;
+    `, queryBookParam);
 };

--- a/backend/src/books/books.type.ts
+++ b/backend/src/books/books.type.ts
@@ -26,8 +26,9 @@ export interface UpdateBookInfo {
   title?: string;
   author?: string;
   publisher?: string;
-  isbn?: string;
+  publishedAt?: string | Date;
   image?: string;
   categoryId?: string;
-  publishedAt?: string | Date;
+  callSign: string;
+  status: number;
 }

--- a/backend/src/books/books.type.ts
+++ b/backend/src/books/books.type.ts
@@ -23,12 +23,17 @@ export interface CreateBookInfo {
 }
 
 export interface UpdateBookInfo {
+  id: number;
   title?: string;
   author?: string;
   publisher?: string;
   publishedAt?: string | Date;
   image?: string;
   categoryId?: string;
+}
+
+export interface UpdateBook {
+  id: number;
   callSign: string;
-  status: number;
+  Status: number;
 }

--- a/backend/src/books/books.type.ts
+++ b/backend/src/books/books.type.ts
@@ -24,11 +24,11 @@ export interface CreateBookInfo {
 
 export interface UpdateBookInfo {
   id: number;
-  title?: string;
-  author?: string;
-  publisher?: string;
-  publishedAt?: string | Date;
-  image?: string;
+  title: string;
+  author: string;
+  publisher: string;
+  publishedAt: string | Date;
+  image: string;
   categoryId?: string;
 }
 

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -859,7 +859,7 @@ router
  * @openapi
  * /api/books/update:
  *    patch:
- *      description: 책 정보를 수정합니다. book_info / book table 
+ *      description: 책 정보를 수정합니다. book_info table or book table 
  *      tags:
  *      - books
  *      requestBody:

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -943,4 +943,4 @@ router
  *                    type: json
  *                    example : { errorCode: 311 }
  */
-.patch('/update'/*, authValidate(roleSet.librarian)*/, updateBookInfo);
+.patch('/update', authValidate(roleSet.librarian), updateBookInfo);

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -859,7 +859,7 @@ router
  * @openapi
  * /api/books/update:
  *    patch:
- *      description: 책 정보를 수정한다. book_info table만 수정.
+ *      description: 책 정보를 수정합니다. book_info / book table 
  *      tags:
  *      - books
  *      requestBody:
@@ -915,21 +915,21 @@ router
  *                  example: 0
  *      responses:
  *         '204':
- *            description: 성공했을 때 http 상태코드 204(NO_CONTENT) 값을 반환합니다.
+ *            description: 성공했을 때 http 상태코드 204(NO_CONTENT) 값을 반환.
  *            content:
  *             application:
  *               schema:
  *                 type: 
- *                 description: 성공했을 때 http 상태코드 204 값을 반환합니다.
+ *                 description: 성공했을 때 http 상태코드 204 값을 반환.
  *         '실패 케이스 1':
- *              description: 예상치 못한 에러로 책 정보 patch에 실패함.
+ *              description: 예상치 못한 에러로 책 정보 patch에 실패.
  *              content:
  *                application/json:
  *                  schema:
  *                    type: json
  *                    example : { errorCode: 312 }
  *         '실패 케이스 2':
- *              description: 수정할 DATA가 적어도 한 개는 필요함. 수정할 DATA가 없음"
+ *              description: 수정할 DATA가 적어도 한 개는 필요. 수정할 DATA가 없음"
  *              content:
  *                application/json:
  *                  schema:

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -857,52 +857,62 @@ router
 router
 /**
  * @openapi
- * /api/books/update/{bookInfoId}:
+ * /api/books/update:
  *    patch:
  *      description: 책 정보를 수정한다. book_info table만 수정.
  *      tags:
  *      - books
- *      parameters:
- *      - name: bookInfoId
- *        in: path
- *        description: book_info Id
- *        required: true
- *        schema:
- *          type: integer
  *      requestBody:
  *        content:
  *          application/json:
  *            schema:
  *              type: object
  *              properties:
+ *                bookInfoId:
+ *                  description: bookInfoId
+ *                  type: integer
+ *                  nullable: false
+ *                  example: 1
  *                title:
+ *                  description: 제목
  *                  type: string
  *                  nullable: true
  *                  example: "작별인사 (김영하 장편소설)"
  *                author:
+ *                  description: 저자
  *                  type: string
  *                  nullable: true
  *                  example: "김영하"
  *                publisher:
+ *                  description: 출판사
  *                  type: string
  *                  nullable: true
  *                  example: "복복서가"
- *                isbn:
- *                  type: string
- *                  nullable: true
- *                  example: 9788065960874
- *                image:
- *                  type: string
- *                  nullable: true
- *                  example: "https://bookthumb-phinf.pstatic.net/cover/223/538/22353804.jpg?type=m1&udate=20220608"
- *                categoryId:
- *                  type: string
- *                  nullable: true
- *                  example: 1
  *                publishedAt:
+ *                  description: 출판연월
  *                  type: string
  *                  nullable: true
  *                  example: "20200505"
+ *                image:
+ *                  description: 표지이미지
+ *                  type: string
+ *                  nullable: true
+ *                  example: "https://bookthumb-phinf.pstatic.net/cover/223/538/22353804.jpg?type=m1&udate=20220608"
+ *                bookId:
+ *                  description: bookId
+ *                  type: integer
+ *                  nullable: false
+ *                  example: 1
+ *                callSign:
+ *                  description: 청구기호
+ *                  type: string
+ *                  nullable: true
+ *                  example: h1.18.v1.c1
+ *                status:
+ *                  description: 도서 상태
+ *                  type: integer
+ *                  nullable: false
+ *                  example: 0
  *      responses:
  *         '204':
  *            description: 성공했을 때 http 상태코드 204(NO_CONTENT) 값을 반환합니다.
@@ -933,4 +943,4 @@ router
  *                    type: json
  *                    example : { errorCode: 311 }
  */
-.patch('/update/:bookInfoId'/*, authValidate(roleSet.librarian)*/, updateBookInfo);
+.patch('/update'/*, authValidate(roleSet.librarian)*/, updateBookInfo);


### PR DESCRIPTION
### 개요
도서 정보 수정 FIGMA에 맞춰서 수정 범위 재조정

### 작업 사항
- [x] interface
- [x] controller
- [x] service
- [x] routes

### 변경점
 - interface
> book_info 수정되면 안되는 부분인 isbn을 삭제하였습니다.
> book 수정해야할 부분인 callSign과 status를 삽입하였습니다.
> book_info_id / book_id를 interface에 추가하였습니다.

 - controller
 > interface type을 추가하고 해당 타입들에 관하여 값을 부여하였습니다.
 > book테이블에 예외처리 및 trim 적용 하였습니다.
 > service로 넘겨주는 파라미터값을 변경하였습니다.
 
 - service
 > controller에서 받아오는 매개변수 값을 bookinfo와 book으로 구분하였습니다.
 > 넘어오는 bookinfo / book interface type의 매개변수 값을 토대로 업데이트를 2번 진행합니다.
 
 - routes
 > swagger API를 변경하였습니다.
 >  bookInfoId / bookId 두 가지 값을 명확히 제시해주므로 parameters: 와 /:bookInfoId 를 삭제하였습니다. 
 > 필요없는 정보인 isbn, categoryID를 삭제하였습니다.
 > 필요한 정보인 bookInfoId, bookId, callSign, status를 추가하였습니다.
 > swagger 어색한 정보를 수정하였습니다.

 
### 목적
 - 책 정보 수정
 
### 스크린샷 (optional)
<img width="408" alt="image" src="https://user-images.githubusercontent.com/85754295/195670209-9e2e9942-fd27-44b4-a30a-fca34dc23be1.png">
