### PR TITLE
240 proposal 42 시크릿이 없을 때 에러로그 상세화

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import swaggerOptions from './swagger/swagger';
 import errorHandler from './utils/error/errorHandler';
 import { FtStrategy, JwtStrategy, FtAuthentication } from './auth/auth.strategy';
 import { morganMiddleware } from './utils/logger';
+import errorConverter from './utils/error/errorConverter';
 
 const app: express.Application = express();
 const cors = require('cors');
@@ -43,5 +44,6 @@ app.use(
 app.use('/api', router);
 
 // 에러 핸들러
+app.use(errorConverter);
 app.use(errorHandler);
 export default app;

--- a/backend/src/utils/error/errorCode.ts
+++ b/backend/src/utils/error/errorCode.ts
@@ -1,6 +1,7 @@
 export const UNKNOWN_ERROR = '0';
 export const QUERY_EXECUTION_FAILED = '1';
 export const INVALID_INPUT = '2';
+export const CLIENT_AUTH_FAILED = '42';
 
 export const NO_AUTHORIZATION = '100';
 export const NO_USER = '101';
@@ -64,3 +65,5 @@ export const INVALID_INPUT_REVIEWS_ID = '810';
 export const INVALID_INPUT_REVIEWS_CONTENT = '811';
 
 export const UNAUTHORIZED = '700';
+
+export const CLIENT_AUTH_FAILED_ERROR_MESSAGE = 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'

--- a/backend/src/utils/error/errorConverter.ts
+++ b/backend/src/utils/error/errorConverter.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from 'express';
+import * as Status from 'http-status';
+import ErrorResponse from './errorResponse';
+import { logger } from '../logger';
+import * as errorCode from './errorCode';
+
+export default function errorConverter(
+  err: Error | ErrorResponse,
+  req: Request,
+  res: Response,
+  // eslint-disable-next-line no-unused-vars
+  next: NextFunction,
+) {
+  if (err.message == errorCode.CLIENT_AUTH_FAILED_ERROR_MESSAGE) { 
+    return next(new ErrorResponse('42', 500, '42KeyError'));
+  }
+  next(err);
+};


### PR DESCRIPTION
### 개요
42 시크릿 키 없을 때 에러로그 상세화

### 작업 사항
errorConverter 를 통하여 42키가 없을 때의 에러 로그를 잡아서 던져줄 수 있도록 작업 하였습니다.

### 변경점
errorConverter.ts
errorCode.ts
app.ts

### 목적
42 key error 상세화

### 스크린샷 (optional)
<img width="246" alt="image" src="https://user-images.githubusercontent.com/85754295/199474386-a2fde3d5-36ad-4fd3-b056-457c0646b28e.png">
