### PR TITLE
FEAT: 연체일이 지나면 하루에 한번씩 계속 알림

### DIFF
--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -154,7 +154,7 @@ export const notifyOverdue = async () => {
     LEFT JOIN user ON
       lending.userId = user.id
     WHERE
-    DATEDIFF(CURDATE(), lending.createdAt) = 15 AND
+    DATEDIFF(CURDATE(), lending.createdAt) >= 15 AND
     lending.returnedAt IS NULL
   `);
   lendings.forEach(async (lending) => {


### PR DESCRIPTION
### 개요
FEAT: 연체일이 지나면 하루에 한번씩 계속 알림

### 작업 사항
기존 대출일로부터 15일 지난 대출들만 알림을 보낸던 것에서 대출일로부터 15일이 지나면 계속해서 알림을 보내게 수정

### 목적
연체률을 낮추기 위함

### 향후 모니터링 사항
 실제로 연체률이 떨어지는지 확인