### PR TITLE
FEAT:  연체자 슬랙 메시지 시간 조정

### DIFF
--- a/backend/src/utils/scheduler.ts
+++ b/backend/src/utils/scheduler.ts
@@ -7,6 +7,7 @@ const midnightScheduler = () => {
   rule.dayOfWeek = [0, new schedule.Range(0, 6)];
   rule.hour = 0;
   rule.minute = 42;
+  rule.tz = 'Asia/Seoul';
   schedule.scheduleJob(rule, async () => {
     await slack.updateSlackId();
     await notifications.notifyReservationOverdue();
@@ -16,8 +17,9 @@ const midnightScheduler = () => {
 const noonScheduler = () => {
   const rule = new schedule.RecurrenceRule();
   rule.dayOfWeek = [0, new schedule.Range(0, 6)];
-  rule.hour = 12;
-  rule.minute = 0;
+  rule.hour = 9;
+  rule.minute = 42;
+  rule.tz = 'Asia/Seoul';
   schedule.scheduleJob(rule, async () => {
     await notifications.notifyReservation();
     await notifications.notifyReturningReminder();

--- a/backend/src/utils/scheduler.ts
+++ b/backend/src/utils/scheduler.ts
@@ -14,7 +14,7 @@ const midnightScheduler = () => {
   });
 };
 
-const noonScheduler = () => {
+const morningScheduler = () => {
   const rule = new schedule.RecurrenceRule();
   rule.dayOfWeek = [0, new schedule.Range(0, 6)];
   rule.hour = 9;
@@ -29,7 +29,7 @@ const noonScheduler = () => {
 
 export const scheduler = () => {
   midnightScheduler();
-  noonScheduler();
+  morningScheduler();
 };
 
 export default scheduler;


### PR DESCRIPTION
### 개요
연체자 슬랙 메시지 시간 조정

### 작업 사항
- timezone을 서울로 변경
- 9시 42분에 알림가게 변경

### 관련 이슈
#259 