### PR TITLE
HOTFIX: 로그인상황에서 req.user에 정보 담기

### DIFF
--- a/backend/src/auth/auth.validateDefaultNullUser.ts
+++ b/backend/src/auth/auth.validateDefaultNullUser.ts
@@ -15,7 +15,7 @@ const authValidateDefaultNullUser = (roles: role[]) => async (
   next: Function,
 ) : Promise<void> => {
   if (!req.cookies.access_token) {
-    req.user = { intraProfile: req.user, id: null, role: null };
+    req.user = { intraProfile: null, id: null, role: null };
     next();
   } else {
     try {

--- a/backend/src/auth/auth.validateDefaultNullUser.ts
+++ b/backend/src/auth/auth.validateDefaultNullUser.ts
@@ -1,6 +1,13 @@
 import { Request, Response } from 'express';
-import authValidate from './auth.validate';
+import { verify } from 'jsonwebtoken';
+import * as status from 'http-status';
+import * as usersService from '../users/users.service';
 import { role } from './auth.type';
+import { User } from '../users/users.model';
+import config from '../config';
+import ErrorResponse from '../utils/error/errorResponse';
+import { logger } from '../utils/logger';
+import * as errorCode from '../utils/error/errorCode';
 
 const authValidateDefaultNullUser = (roles: role[]) => async (
   req: Request,
@@ -11,7 +18,46 @@ const authValidateDefaultNullUser = (roles: role[]) => async (
     req.user = { intraProfile: req.user, id: null, role: null };
     next();
   } else {
-    authValidate(roles);
+    try {
+      // 토큰 복호화
+      const verifyCheck = verify(req.cookies.access_token, config.jwt.secret);
+      const { id } = verifyCheck as any;
+      const user: { items: User[] } = await usersService.searchUserById(id);
+      // User가 없는 경우
+      if (user.items.length === 0) {
+        throw new ErrorResponse(errorCode.NO_USER, 410);
+      }
+      // 권한이 있지 않은 경우
+      if (!roles.includes(user.items[0].role)) {
+        throw new ErrorResponse(errorCode.NO_AUTHORIZATION, 403);
+      }
+      req.user = { intraProfile: req.user, id, role: user.items[0].role };
+      next();
+    } catch (error: any) {
+      switch (error.message) {
+      // 토큰에 대한 오류를 판단합니다.
+        case 'INVALID_TOKEN':
+        case 'TOKEN_IS_ARRAY':
+        case 'NO_USER':
+          return next(new ErrorResponse(errorCode.TOKEN_NOT_VALID, status.UNAUTHORIZED));
+        case 'EXPIRED_TOKEN':
+          return next(new ErrorResponse(errorCode.EXPIRATION_TOKEN, status.GONE));
+        default:
+          break;
+      }
+      if (error instanceof ErrorResponse) {
+        next(error);
+      }
+      const errorNumber = parseInt(error.message, 10);
+      if (errorNumber >= 100 && errorNumber < 200) {
+        next(new ErrorResponse(error.message, status.BAD_REQUEST));
+      } else if (error.message === 'DB error') {
+        next(new ErrorResponse(errorCode.QUERY_EXECUTION_FAILED, status.INTERNAL_SERVER_ERROR));
+      } else {
+        logger.error(error);
+        next(new ErrorResponse(errorCode.UNKNOWN_ERROR, status.INTERNAL_SERVER_ERROR));
+      }
+    }
   }
 };
 


### PR DESCRIPTION
### 개요
로그인상황에서 req.user에 정보 담기

미들웨어로 authValidate를 호출하려고 했지만, 호출이 안 되고 있음.
따라서 authValidate()안에서 로그인후에 했던 내용들을 그대로 가지고 옴.

### 기술부채
 authValidate()와 코드가 중복임. authValidateDefalutNullUser에서 authValidate를 호출하거나, 통합하여 분기하는 코드가 필요함.

### 목적
 로그인 상황에서 get 요청 성공

### 중요하지 않은 작업사항
 req.user.intraProfile에 기본값 null로 수정
 
 ### 테스트

로컬 스웨거에서 로그인 상황, 비로그인 상황에서 get 요청이 오는 것 확인

<img width="663" alt="Screen Shot 2022-12-02 at 2 57 20 PM" src="https://user-images.githubusercontent.com/62806979/205225176-cc50b67a-b40b-411e-855a-4d5d0573c917.png">

<img width="1129" alt="Screen Shot 2022-12-02 at 2 57 09 PM" src="https://user-images.githubusercontent.com/62806979/205225147-d6ef65a6-5391-459c-9c9a-86a696bddd33.png">

