### PR TITLE
REFACT: reviews 최대 길이 변경

### DIFF
--- a/backend/src/reviews/controller/utils/errorCheck.ts
+++ b/backend/src/reviews/controller/utils/errorCheck.ts
@@ -5,7 +5,7 @@ export const contentParseCheck = (
   content : string,
 ) => {
   const result = content.trim();
-  if (result === '' || result.length < 10 || result.length > 100) {
+  if (result === '' || result.length < 10 || result.length > 420) {
     throw new Error(errorCode.INVALID_INPUT_REVIEWS_CONTENT);
   }
   return result;

--- a/backend/src/routes/reviews.routes.ts
+++ b/backend/src/routes/reviews.routes.ts
@@ -14,7 +14,7 @@ router
      * @openapi
      * /api/reviews:
      *    post:
-     *      description: 책 리뷰를 작성한다. content 길이는 10글자 이상 100글자 이하로 입력하여야 한다.
+     *      description: 책 리뷰를 작성한다. content 길이는 10글자 이상 420글자 이하로 입력하여야 한다.
      *      tags:
      *      - reviews
      *      requestBody:

--- a/database/00_create_table.sql
+++ b/database/00_create_table.sql
@@ -166,7 +166,7 @@ CREATE TABLE `reviews` (
   `updateUserId` int NOT NULL,
   `isDeleted` boolean NOT NULL DEFAULT FALSE,
   `deleteUserId` int DEFAULT NULL,
-  `content` varchar(255) NOT NULL,
+  `content` text NOT NULL,
   `disabled` boolean NOT NULL DEFAULT FALSE,
   `disabledUserId` int DEFAULT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
### 제안 내용
- reviews 테이블의 content 길이를 최대 420자로 수정합니다. 

### 기능 내용

- [x] reviews 테이블 sql content 데이터 타입 varchar255 -> text 
- [x] POST: reviews swagger 최대길이 100자 -> 420자
- [x] reviews contentParseCheck 최대 길이 100 -> 420자