### PR TITLE
FEAT: reviews api 반환값 추가

### DIFF
--- a/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
+++ b/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
@@ -5,11 +5,13 @@ export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sor
     .getBookinfoReviewsPageNoOffset(bookInfoId, reviewsId, sort);
   const counts = await bookInfoReviewsRepository
     .getBookInfoReviewsCounts(bookInfoId, reviewsId, sort);
+  const finalReviewsId = items[items.length - 1]?.reviewsId;
   const meta = {
     totalLeftItems: counts,
     itemsPerPage: 10,
     totalLeftPages: parseInt(String(counts / 10), 10),
     finalPage: counts <= 10,
+    finalReviewsId: finalReviewsId === undefined ? -1 : finalReviewsId,
   };
   return { items, meta };
 };

--- a/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
+++ b/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
@@ -11,7 +11,7 @@ export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sor
     itemsPerPage: 10,
     totalLeftPages: parseInt(String(counts / 10), 10),
     finalPage: counts <= 10,
-    finalReviewsId: finalReviewsId === undefined ? -1 : finalReviewsId,
+    finalReviewsId,
   };
   return { items, meta };
 };

--- a/backend/src/routes/bookInfoReviews.routes.ts
+++ b/backend/src/routes/bookInfoReviews.routes.ts
@@ -13,7 +13,7 @@ router
  *    get:
  *      description: 책 리뷰 10개를 반환한다. 최종 페이지의 경우 1 <= n <= 10 개의 값이 반환될 수 있다. content에는 리뷰에 대한 정보를,
  *        finalPage 에는 해당 페이지가 마지막인지에 대한 여부를 boolean 값으로 반환한다. finalReviewsId는 마지막 리뷰의 Id를 반환하며, 반환할
- *        아이디가 존재하지 않는 경우에는 -1을 반환한다.
+ *        아이디가 존재하지 않는 경우에는 해당 인자를 반환하지 않는다.
  *      tags:
  *      - bookInfo/reviews
  *      parameters:

--- a/backend/src/routes/bookInfoReviews.routes.ts
+++ b/backend/src/routes/bookInfoReviews.routes.ts
@@ -12,7 +12,8 @@ router
  * /api/book-info/{bookInfoId}/reviews:
  *    get:
  *      description: 책 리뷰 10개를 반환한다. 최종 페이지의 경우 1 <= n <= 10 개의 값이 반환될 수 있다. content에는 리뷰에 대한 정보를,
- *        finalPage 에는 해당 페이지가 마지막인지에 대한 여부를 boolean 값으로 반환한다.
+ *        finalPage 에는 해당 페이지가 마지막인지에 대한 여부를 boolean 값으로 반환한다. finalReviewsId는 마지막 리뷰의 Id를 반환하며, 반환할
+ *        아이디가 존재하지 않는 경우에는 -1을 반환한다.
  *      tags:
  *      - bookInfo/reviews
  *      parameters:
@@ -83,7 +84,8 @@ router
  *                        totalItems: 100,
  *                        itemsPerPage : 5,
  *                        totalPages : 20,
- *                        finalPage : False
+ *                        finalPage : False,
+ *                        finalReviewsId : 104
  *                      }
  *        '400':
  *           content:


### PR DESCRIPTION
### 제안 내용
- 프론트엔드의 요청사항으로 GET: book-info/{bookInfoId}/reviews API 반환값으로 finalReviewsId를 추가합니다.

### 기능 내용

- [x] GET: book-info/{bookInfoId}/reviews API 반환값으로 meta에 finalReviewsId 추가합니다. 반환할 reviewsId가 존재하지 않는 경우에는 해당 인자를 반환하지 않습니다.
