### PR TITLE
297 proposal apibook infobookinfoidreviews api 형식 제안

### DIFF
--- a/backend/src/book-info-reviews/controller/bookInfoReviews.controller.ts
+++ b/backend/src/book-info-reviews/controller/bookInfoReviews.controller.ts
@@ -14,7 +14,8 @@ export const getBookInfoReviewsPage = async (
   const bookInfoId = errorCheck.bookInfoParseCheck(req?.params?.bookInfoId);
   const reviewsId = parseCheck.reviewsIdParse(req?.query?.reviewsId);
   const sort : 'asc' | 'desc' = parseCheck.sortParse(req?.query?.sort);
+  const limit = parseInt(String(req?.query?.limit), 10);
   return res
     .status(status.OK)
-    .json(await bookInfoReviewsService.getPageNoOffset(bookInfoId, reviewsId, sort));
+    .json(await bookInfoReviewsService.getPageNoOffset(bookInfoId, reviewsId, sort, limit));
 };

--- a/backend/src/book-info-reviews/repository/bookInfoReviews.repository.ts
+++ b/backend/src/book-info-reviews/repository/bookInfoReviews.repository.ts
@@ -1,11 +1,12 @@
 import { executeQuery } from '../../mysql';
 
-export const getBookinfoReviewsPageNoOffset = async (bookInfoId: number, reviewsId: number, sort: 'asc' | 'desc') => {
+export const getBookinfoReviewsPageNoOffset = async (bookInfoId: number, reviewsId: number, sort: 'asc' | 'desc', limit: number) => {
   const bookInfoIdQuery = (Number.isNaN(bookInfoId)) ? '' : `AND reviews.bookInfoId = ${bookInfoId}`;
   const sign = sort === 'asc' ? '>' : '<';
   const reviewIdQuery = (Number.isNaN(reviewsId)) ? '' : `AND reviews.id ${sign} ${reviewsId}`;
   const sortQuery = `ORDER BY reviews.id ${sort}`;
   if (bookInfoIdQuery === '') { return []; }
+  const limitQuery = (Number.isNaN(limit)) ? 'LIMIT 10' : `LIMIT ${limit}`;
 
   const reviews = await executeQuery(`
   SELECT
@@ -18,13 +19,13 @@ export const getBookinfoReviewsPageNoOffset = async (bookInfoId: number, reviews
     user.nickname
   FROM reviews
   JOIN user ON user.id = reviews.userId
-  JOIN book_info ON reviews.bookInfoId = book_info.id  
+  JOIN book_info ON reviews.bookInfoId = book_info.id
   WHERE reviews.isDeleted = false
   AND reviews.disabled = false
     ${bookInfoIdQuery}
     ${reviewIdQuery}
     ${sortQuery}
-  LIMIT 10
+  ${limitQuery}
   `);
   return (reviews);
 };

--- a/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
+++ b/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
@@ -1,18 +1,19 @@
 import { DOMAIN_URL } from '../../utils/error/errorCode';
 import * as bookInfoReviewsRepository from '../repository/bookInfoReviews.repository';
 
-export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sort: 'asc' | 'desc') => {
+export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sort: 'asc' | 'desc', limit: number) => {
   const items = await bookInfoReviewsRepository
-    .getBookinfoReviewsPageNoOffset(bookInfoId, reviewsId, sort);
+    .getBookinfoReviewsPageNoOffset(bookInfoId, reviewsId, sort, limit);
   const counts = await bookInfoReviewsRepository
     .getBookInfoReviewsCounts(bookInfoId, reviewsId, sort);
+  const itemsPerPage = (Number.isNaN(limit)) ? 10 : limit;
   const finalReviewsId = items[items.length - 1]?.reviewsId;
   // 추후에 DOMAIN_URL을 환경변수로 대체합니다.
-  const next = (counts <= 10) ? undefined : `${DOMAIN_URL}/api/book-info/${bookInfoId}/reviews/reviewsId=${finalReviewsId}`;
+  const next = (counts <= itemsPerPage) ? undefined : `${DOMAIN_URL}/api/book-info/${bookInfoId}/reviews/reviewsId=${finalReviewsId}`;
   const meta = {
     totalLeftItems: counts,
-    itemsPerPage: 10,
-    totalLeftPages: parseInt(String(counts / 10), 10),
+    itemsPerPage,
+    totalLeftPages: parseInt(String(counts / itemsPerPage), 10),
     next
   };
   return { items, meta };

--- a/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
+++ b/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
@@ -1,3 +1,4 @@
+import { DOMAIN_URL } from '../../utils/env_temp';
 import * as bookInfoReviewsRepository from '../repository/bookInfoReviews.repository';
 
 export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sort: 'asc' | 'desc', limit: number) => {
@@ -8,7 +9,7 @@ export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sor
   const itemsPerPage = (Number.isNaN(limit)) ? 10 : limit;
   const finalReviewsId = items[items.length - 1]?.reviewsId;
   // 추후에 DOMAIN_URL을 환경변수로 대체합니다.
-  const next = (counts <= itemsPerPage) ? undefined : `${process.env.CLIENT_URL}/api/book-info/${bookInfoId}/reviews/reviewsId=${finalReviewsId}`;
+  const next = (counts <= itemsPerPage) ? undefined : `${DOMAIN_URL}/api/book-info/${bookInfoId}/reviews/reviewsId=${finalReviewsId}`;
   const meta = {
     totalLeftItems: counts,
     itemsPerPage,

--- a/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
+++ b/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
@@ -1,4 +1,3 @@
-import { DOMAIN_URL } from '../../utils/error/errorCode';
 import * as bookInfoReviewsRepository from '../repository/bookInfoReviews.repository';
 
 export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sort: 'asc' | 'desc', limit: number) => {
@@ -9,7 +8,7 @@ export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sor
   const itemsPerPage = (Number.isNaN(limit)) ? 10 : limit;
   const finalReviewsId = items[items.length - 1]?.reviewsId;
   // 추후에 DOMAIN_URL을 환경변수로 대체합니다.
-  const next = (counts <= itemsPerPage) ? undefined : `${DOMAIN_URL}/api/book-info/${bookInfoId}/reviews/reviewsId=${finalReviewsId}`;
+  const next = (counts <= itemsPerPage) ? undefined : `${process.env.CLIENT_URL}/api/book-info/${bookInfoId}/reviews/reviewsId=${finalReviewsId}`;
   const meta = {
     totalLeftItems: counts,
     itemsPerPage,

--- a/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
+++ b/backend/src/book-info-reviews/service/bookInfoReviews.service.ts
@@ -1,3 +1,4 @@
+import { DOMAIN_URL } from '../../utils/error/errorCode';
 import * as bookInfoReviewsRepository from '../repository/bookInfoReviews.repository';
 
 export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sort: 'asc' | 'desc') => {
@@ -6,12 +7,13 @@ export const getPageNoOffset = async (bookInfoId: number, reviewsId: number, sor
   const counts = await bookInfoReviewsRepository
     .getBookInfoReviewsCounts(bookInfoId, reviewsId, sort);
   const finalReviewsId = items[items.length - 1]?.reviewsId;
+  // 추후에 DOMAIN_URL을 환경변수로 대체합니다.
+  const next = (counts <= 10) ? undefined : `${DOMAIN_URL}/api/book-info/${bookInfoId}/reviews/reviewsId=${finalReviewsId}`;
   const meta = {
     totalLeftItems: counts,
     itemsPerPage: 10,
     totalLeftPages: parseInt(String(counts / 10), 10),
-    finalPage: counts <= 10,
-    finalReviewsId,
+    next
   };
   return { items, meta };
 };

--- a/backend/src/routes/bookInfoReviews.routes.ts
+++ b/backend/src/routes/bookInfoReviews.routes.ts
@@ -19,17 +19,25 @@ router
  *      - name: bookInfoId
  *        required: true
  *        in: path
+ *        schema:
+ *          type: number
  *        description: bookInfoId에 해당 하는 리뷰 페이지를 반환한다.
  *      - name: reviewsId
  *        in: query
+ *        schema:
+ *          type: number
  *        required: false
- *        description: 해당 reviewsId를 조건으로 asd 기준 이후, desc 기준 이전의 페이지를 반환한다. 기본값은 첫 페이지를 반환한다.
+ *        description: 해당 reviewsId를 조건으로 asc 기준 이후, desc 기준 이전의 페이지를 반환한다. 기본값은 첫 페이지를 반환한다.
  *      - name: sort
  *        in: query
+ *        schema:
+ *          type: string
  *        required: false
- *        description: asd, desc 값을 통해 시간순으로 정렬된 페이지를 반환한다. 기본값은 asd으로 한다.
+ *        description: asc, desc 값을 통해 시간순으로 정렬된 페이지를 반환한다. 기본값은 asd으로 한다.
  *      - name: limit
  *        in: query
+ *        schema:
+ *          type: number
  *        description: 한 페이지에서 몇 개의 게시글을 가져올 지 결정한다. [default = 10]
  *      responses:
  *        '200':

--- a/backend/src/routes/bookInfoReviews.routes.ts
+++ b/backend/src/routes/bookInfoReviews.routes.ts
@@ -12,8 +12,7 @@ router
  * /api/book-info/{bookInfoId}/reviews:
  *    get:
  *      description: 책 리뷰 10개를 반환한다. 최종 페이지의 경우 1 <= n <= 10 개의 값이 반환될 수 있다. content에는 리뷰에 대한 정보를,
- *        finalPage 에는 해당 페이지가 마지막인지에 대한 여부를 boolean 값으로 반환한다. finalReviewsId는 마지막 리뷰의 Id를 반환하며, 반환할
- *        아이디가 존재하지 않는 경우에는 해당 인자를 반환하지 않는다.
+ *                   next에는 다음에 호출할 api url을 반환한다. 다음에 호출할 데이터가 없다면 next는 정의되지 않는다.
  *      tags:
  *      - bookInfo/reviews
  *      parameters:
@@ -84,8 +83,7 @@ router
  *                        totalItems: 100,
  *                        itemsPerPage : 5,
  *                        totalPages : 20,
- *                        finalPage : False,
- *                        finalReviewsId : 104
+ *                        next : https://42library/api/book-info/1/reviews/reviewsId=104
  *                      }
  *        '400':
  *           content:

--- a/backend/src/routes/bookInfoReviews.routes.ts
+++ b/backend/src/routes/bookInfoReviews.routes.ts
@@ -28,6 +28,9 @@ router
  *        in: query
  *        required: false
  *        description: asd, desc 값을 통해 시간순으로 정렬된 페이지를 반환한다. 기본값은 asd으로 한다.
+ *      - name: limit
+ *        in: query
+ *        description: 한 페이지에서 몇 개의 게시글을 가져올 지 결정한다. [default = 10]
  *      responses:
  *        '200':
  *           content:

--- a/backend/src/utils/env_temp.ts
+++ b/backend/src/utils/env_temp.ts
@@ -1,0 +1,1 @@
+export const DOMAIN_URL = 'https://42library.kr';

--- a/backend/src/utils/error/errorCode.ts
+++ b/backend/src/utils/error/errorCode.ts
@@ -72,6 +72,3 @@ export const INVALID_INPUT_REVIEWS_CONTENT = '811';
 export const UNAUTHORIZED = '700';
 
 export const CLIENT_AUTH_FAILED_ERROR_MESSAGE = 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.';
-
-// 추후에 환경변수로 변경예정
-export const DOMAIN_URL = 'https://42library.kr';

--- a/backend/src/utils/error/errorCode.ts
+++ b/backend/src/utils/error/errorCode.ts
@@ -72,3 +72,6 @@ export const INVALID_INPUT_REVIEWS_CONTENT = '811';
 export const UNAUTHORIZED = '700';
 
 export const CLIENT_AUTH_FAILED_ERROR_MESSAGE = 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.';
+
+// 추후에 환경변수로 변경예정
+export const DOMAIN_URL = 'https://42library.kr';


### PR DESCRIPTION
## [proposal] reviews-api 형식 제안

### 제안 내용

- [x] 현재 /api/book-info/{bookInfoId}/reviews 요청의 반환값에 있는 finalPage, finalReviewsId를 next로 교체합니다.
- [x] 해당 요청에 한 페이지에 가져올 리뷰의 개수를 의미하는 limit 인자를 query인자로 추가합니다.
- [x] swagger 문서 파라미터 type 명시 + 최신화

### 변경점

1.
![image](https://user-images.githubusercontent.com/30787477/206376560-77b08933-030b-4757-95c5-39953629fa68.png)
->facebook에서의 무한스크롤 API방식.
->출처: https://developers.facebook.com/docs/graph-api/results?locale=ko_KR

기존의 방식에서
finalPage값으로 현재 페이지가 마지막 페이지인지 여부를,
finalReviewsId값으로 다음에 요청할 페이지의 시작범위를 지정해주었습니다.

이 방식대신 다음 페이지를 가져오는 api url을 next필드에 담아서 넣어주는 방식을 제안합니다.
만약 현재 요청으로 가져온 리뷰페이지가 마지막페이지인 경우에는, next필드를 넣어주지 않습니다.

2.
한 페이지에서 가져올 리뷰의 개수를 전달받습니다. limit값을 query parameter로 전달받을 수 있습니다.

3.
swagger문서에서 해당 api의 파라미터 type을 명시했습니다.