### PR TITLE
FIX: modify VLendingForSearchUser table - get tuple only not returned…

### DIFF
--- a/backend/src/entity/entities/VLendingForSearchUser.ts
+++ b/backend/src/entity/entities/VLendingForSearchUser.ts
@@ -14,6 +14,7 @@ import { DataSource, ViewColumn, ViewEntity } from 'typeorm';
     .addSelect('CASE WHEN DATEDIFF(now(), DATE_ADD(l.createdAt, INTERVAL 14 DAY)) < 0 THEN 0 ELSE DATEDIFF(now(), DATE_ADD(l.createdAt, INTERVAL 14 DAY)) END', 'overDueDay')
     .addSelect('(SELECT COUNT(r.id) FROM reservation r WHERE r.userId = l.userId)', 'reservedNum')
     .from('lending', 'l')
+    .where('l.returnedAt is NULL')
     .innerJoin('user', 'u', 'l.userId = u.id')
     .leftJoin('book', 'b', 'l.bookId = b.id')
     .leftJoin('book_info', 'bi', 'b.infoid = bi.id'),

--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -1,5 +1,5 @@
 import { QueryRunner } from 'typeorm/query-runner/QueryRunner';
-import { IsNull, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import Reservation from '../entity/entities/Reservation';
 import UserReservation from '../entity/entities/UserReservation';
 import * as models from './users.model';
@@ -81,7 +81,6 @@ export default class UsersRepository extends Repository<User> {
     const userLendingList = await this.lendingForSearchUserRepo.find({
       where: {
         userId,
-        lendDate: IsNull(),
       },
     }) as unknown as models.Lending[];
     return userLendingList;


### PR DESCRIPTION
VLendingForSearchUser 수정

### 개요
유저목록을 가져올 때 유저의 대여목록을 가져오기 위한 VTable인 VLendingForSearchUser에 문제가 있습니다.
VLendingForSearchUser에서 대여 목록을 가져오지 못해 언제나 빈 배열을 가져옵니다.

### 작업 사항
VLendingForSearchUser expression식에 where조건을 추가했습니다.
VLendingForSearchUser은 반납된 대여사항과 그렇지 않은 대여사항을 구분하지 않은 채로 조회됩니다.

### 변경점
반납되지 않은 대여사항만 가져오도록 수정하였습니다.
VLendingForSearchUser를 사용하는 service에서 호출방법을 수정했습니다.

### 목적
유저 검색에서 검색된 유저의 대여목록을 추적하기 위해 기능을 Fix합니다.