### PR TITLE
HOTFIX: penaltyEndDate, dateFomat

### DIFF
--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -60,6 +60,11 @@ export default class UsersRepository extends Repository<User> {
       skip: page * limit,
     });
     const customUsers = users as unknown as models.User[];
+    customUsers.forEach(user => {
+      const penaltyEndDate: Date = user.penaltyEndDate as Date;
+      const formattedPenaltyEndDate: String = formatDate(penaltyEndDate);
+      user.penaltyEndDate = formattedPenaltyEndDate as unknown as Date;
+     })
     return [customUsers, count];
   }
 


### PR DESCRIPTION
### 개요
penaltyEndDate의 반환 형식이 달라서 프론트측에서 스크린샷과 같은 버그가 발생

### 작업 사항
`yyyy-mm-dd` 형식으로 날짜 반환

### 스크린샷 (optional)
<img width="1153" alt="Screen Shot 2023-02-27 at 6 04 11 PM" src="https://user-images.githubusercontent.com/62806979/221557576-ee862729-a5fe-406a-a610-ef2e01fb7932.png">

