### PR TITLE
379 bug 마이페이지에서 이전 대출기록 뜨지 않는 버그 수정

### DIFF
--- a/backend/src/histories/histories.service.ts
+++ b/backend/src/histories/histories.service.ts
@@ -12,7 +12,7 @@ export const getHistories = async (
   page: number,
   limit: number,
 ) => {
-  const filterQuery: any = {};
+  let filterQuery: any = {};
   if (who === 'my') {
     const usersRepo = new UsersRepository();
     const user = (await usersRepo.searchUserBy({ id: userId }, 0, 0))[0];
@@ -23,8 +23,10 @@ export const getHistories = async (
   } else if (type === 'title') {
     filterQuery.title = Like(`%${query}%`);
   } else {
-    filterQuery.login = Like(`%${query}%`);
-    filterQuery.title = Like(`%${query}%`);
+    filterQuery = [
+      { login: Like(`%${query}%`) },
+      { title: Like(`%${query}%`) },
+    ];
   }
   const historiesRepo = new HistoriesRepository();
   const [items, count] = await historiesRepo.getHistoriesItems(filterQuery, limit, page);

--- a/backend/src/histories/histories.service.ts
+++ b/backend/src/histories/histories.service.ts
@@ -1,6 +1,7 @@
 import { Like } from 'typeorm';
 import { Meta } from '../users/users.type';
 import HistoriesRepository from './histories.repository';
+import UsersRepository from '../users/users.repository';
 
 // eslint-disable-next-line import/prefer-default-export
 export const getHistories = async (
@@ -13,7 +14,9 @@ export const getHistories = async (
 ) => {
   const filterQuery: any = {};
   if (who === 'my') {
-    filterQuery.id = userId;
+    const usersRepo = new UsersRepository();
+    const user = (await usersRepo.searchUserBy({ id: userId }, 0, 0))[0];
+    filterQuery.login = user[0].nickname;
   }
   if (type === 'user') {
     filterQuery.login = Like(`%${query}%`);


### PR DESCRIPTION
### 개요
- 마이페이지에서 이전 대출기록 뜨지 않는 버그 수정
- (추가 수정 완료) 전체기록에서 검색 시, 기록이 뜨지 않는 버그 수정

### 작업 사항
- `histories.services.ts` 내 대출 기록 조회 함수의 `filterQuery` 값 설정 부분 변경
