### PR TITLE
FIX: 명시적인 queryRunner 생성 삭제

### DIFF
--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -21,7 +21,7 @@ export default class UsersRepository extends Repository<User> {
   constructor(
     queryRunner?: QueryRunner,
   ) {
-    const qr = queryRunner === undefined ? jipDataSource.createQueryRunner() : queryRunner;
+    const qr = queryRunner;
     const manager = jipDataSource.createEntityManager(qr);
     super(User, manager);
     this.userLendingRepo = new Repository<VUserLending>(


### PR DESCRIPTION
### 개요
 userRepository에서 queryRunner를 명시적으로 호출하고 있었음. 명시적으로 호출시에는 connection 관리를 개발자 스스로 해줘야함 (= typeORM에서 알아서 안 해줌)

명시적으로 호출이 되던 부분을 삭제함

### 최대 기여자
@jhMin95 이 문제 발견! 👍
