### PR TITLE
BUG: 이전 대출기록에 전체 대출기록이 뜨는 현상

### DIFF
--- a/backend/src/histories/histories.service.ts
+++ b/backend/src/histories/histories.service.ts
@@ -17,8 +17,7 @@ export const getHistories = async (
     const usersRepo = new UsersRepository();
     const user = (await usersRepo.searchUserBy({ id: userId }, 0, 0))[0];
     filterQuery.login = user[0].nickname;
-  }
-  if (type === 'user') {
+  } else if (type === 'user') {
     filterQuery.login = Like(`%${query}%`);
   } else if (type === 'title') {
     filterQuery.title = Like(`%${query}%`);


### PR DESCRIPTION
### 개요
- 마이페이지에서 사서 권한이 있는 사용자의 경우, 이전 대출 기록에 모든 사용자의 대출기록이 보임

### 작업 사항
- `histories.services.ts` 내 대출 기록 조회 함수에서 `my`일 경우, 전체 대출기록 조회의 필터를 만드는 조건문을 실행하지 않게 함