### PR TITLE
BUG: 유저 정보 업데이트 시, penaltyEndDated의 값이 있을 때에만 penaltyEndDate 업데이트

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -128,13 +128,15 @@ export default class UsersService {
     if (slackCount > 0) {
       throw new Error(errorCode.SLACK_OVERLAP);
     }
-    const updateParam = {
+    const updateParam: any = {
       nickname,
       intraId,
       slack,
       role,
-      penaltyEndDate,
     };
+    if (penaltyEndDate) {
+      updateParam.penaltyEndDate = penaltyEndDate;
+    }
     const updatedUser = this.usersRepository.updateUser(id, updateParam);
     return (updatedUser);
   }


### PR DESCRIPTION
### 개요
유저 정보 업데이트 시, `penaltyEndDate == null`이면, DB 내의 `user` 테이블에 `penaltyEndDate(not nullable)`에 null이 들어가서 에러 발생

### 작업 사항
유저 업데이트 시, `penaltyEndDate`의 null 여부에 따라 `updateParam`에 할당