### PR TITLE
FEAT: searchUserWithPasswordByEmail() 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -99,7 +99,7 @@ export const login = async (req: Request, res: Response, next: NextFunction): Pr
       throw new ErrorResponse(errorCode.NO_INPUT, 400);
     }
     /* 여기에 id, password의 유효성 검증 한번 더 할 수도 있음 */
-    const user: { items: models.User[] } = await usersService.searchUserByEmail(id);
+    const user: { items: models.User[] } = await usersService.searchUserWithPasswordByEmail(id);
     if (user.items.length === 0) {
       return next(new ErrorResponse(errorCode.NO_ID, 401));
     }

--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -68,6 +68,34 @@ export default class UsersRepository extends Repository<User> {
     return [customUsers, count];
   }
 
+  async searchUserWithPasswordBy(conditions: {}, limit: number, page: number)
+  : Promise<[models.User[], number]> {
+    const [users, count] = await this.findAndCount({
+      select: [
+        'id',
+        'email',
+        'nickname',
+        'intraId',
+        'slack',
+        'penaltyEndDate',
+        'role',
+        'password'
+      ],
+      where: conditions,
+      take: limit,
+      skip: page * limit,
+    });
+    const customUsers = users as unknown as models.User[];
+    customUsers.forEach((user) => {
+      const penaltyEndDate: Date = user.penaltyEndDate as Date;
+      const formattedPenaltyEndDate: String = formatDate(penaltyEndDate);
+      user.penaltyEndDate = formattedPenaltyEndDate as unknown as Date;
+    });
+    return [customUsers, count];
+  }
+
+  
+
   async getLending(users: { userId: number; }[]) {
     if (users.length !== 0) return this.userLendingRepo.find({ where: users });
     return this.userLendingRepo.find();

--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -68,6 +68,9 @@ export default class UsersRepository extends Repository<User> {
     return [customUsers, count];
   }
 
+  /**
+   * @warning : use only password needed
+   */
   async searchUserWithPasswordBy(conditions: {}, limit: number, page: number)
   : Promise<[models.User[], number]> {
     const [users, count] = await this.findAndCount({

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -68,6 +68,11 @@ export default class UsersService {
     return { items };
   }
 
+  async searchUserWithPasswordByEmail(email: string) {
+    const items = (await this.usersRepository.searchUserWithPasswordBy({ email: Like(`%${email}%`) }, 0, 0))[0];
+    return { items };
+  }
+
   async searchUserByIntraId(intraId: number) {
     const items = (await this.usersRepository.searchUserBy({ intraId }, 0, 0))[0];
     return items;


### PR DESCRIPTION
## [bug] 일반 로그인 및 회원가입 안 됨
### 증상
 일반 로그인 및 회원가입 안 됨.

### 이유
 로그인시 password 비교를 위해서 password가 필요한 데 user의 password가 노출이 안 되어 있음. 

### 변경사항
1. user의 password와 함께 유저정보를 반환하는 함수를 users.repository에 생성

### 오류메시지
```
2023-03-07 00:11:07:117 error: data and hash arguments required 
 Error Stack: Error: data and hash arguments required
 ```
![Screen Shot 2023-03-07 at 12 11 47 AM](https://user-images.githubusercontent.com/62806979/223150435-69e09c1b-e2ba-4548-9205-0176cd7c9f3e.png)

### 다른 대안
user view를 새로 만드는 방법도 고려해봤지만, password를 제외하고 똑같이 있는건 불필요한 작업이라고 판단.

### 기타 참고하면 좋을 내용
[js doc](https://stackoverflow.com/questions/34220564/is-there-a-way-to-generate-jsdoc-comments-in-visual-studio-code) 기능을 
```javascript
/** 
```
 을 vscode에 입력하면 자동으로 완성되어서 사용할 수 있습니다.