### PR TITLE
FIX: getReviewsCounts() 함수 number 값 반환

### DIFF
--- a/backend/src/reviews/repository/reviews.repository.ts
+++ b/backend/src/reviews/repository/reviews.repository.ts
@@ -98,8 +98,8 @@ export default class ReviewsRepository extends Repository<Reviews> {
       .where('reviews.isDeleted = false')
       .andWhere(reviewFilter);
     if (disabledQuery !== '') queryBuilder.andWhere(disabledQuery);
-    const ret = queryBuilder.getRawOne();
-    return ret;
+    const ret = await queryBuilder.getRawOne();
+    return ret.counts;
   }
 
   async getReviewsUserId(reviewsId : number): Promise<number> {


### PR DESCRIPTION
### 개요
리뷰페이지 페이지네이션 안 되는 버그 FIX

### 버그 발생 원인
getReviewsCounts() 함수의 반환값이 Promise<number> 라고 명시되어 있지만 실제로는 `{ counts: 42 }` 라는 object가 반환되고 있었음. 

### 작업 사항
FIX: getReviewsCounts() 함수가 Promise<number> 값 반환

### 정상작동 확인 스크린샷
![Screen Shot 2023-03-07 at 1 52 34 AM](https://user-images.githubusercontent.com/62806979/223177521-05c00040-d8f3-4822-9d64-2fb426d61a2a.png)
