### PR TITLE
FIX: `bookInfoId` NaN 확인 오류 수정

### DIFF
--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -345,7 +345,9 @@ export const updateBookInfo = async (
     status: req.body.status,
   };
 
-  if (book.id <= 0 || book.id === NaN || bookInfo.id <= 0 || bookInfo.id === NaN) { return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST)); }
+  if (book.id <= 0 || Number.isNaN(book.id) || bookInfo.id <= 0 || Number.isNaN(bookInfo.id)) {
+    return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
+  }
   if (!(bookInfo.title || bookInfo.author || bookInfo.publisher || bookInfo.image
           || bookInfo.categoryId || bookInfo.publishedAt || book.callSign || book.status !== undefined)) { return next(new ErrorResponse(errorCode.NO_BOOK_INFO_DATA, status.BAD_REQUEST)); }
 

--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -4,7 +4,7 @@ import {
 import * as status from 'http-status';
 import * as errorCode from '../utils/error/errorCode';
 import ErrorResponse from '../utils/error/errorResponse';
-import { isNullish } from '../utils/isNullish';
+import isNullish from '../utils/isNullish';
 import { logger } from '../utils/logger';
 import * as BooksService from './books.service';
 import * as types from './books.type';

--- a/backend/src/utils/isNullish.ts
+++ b/backend/src/utils/isNullish.ts
@@ -1,5 +1,3 @@
-export const isNullish = (value: any) => {
-    if (value === null || value === undefined)
-        return (true);
-    return (false);
-  }
+export default function isNullish(value: unknown) {
+  return (value === null || value === undefined);
+}


### PR DESCRIPTION
### 개요
- fix #393 

### 작업 사항
`=== NaN` 대신 `Number.isNan()` 확인으로 변경

### 변경점
동작에 변경점 없음

### 목적
잘못된 isNaN 체크 오류로 인해 실행되지 않는 현상 방지

