### PR TITLE
397 bug 예약 상태 표기오류

### DIFF
--- a/backend/src/entity/entities/VLendingForSearchUser.ts
+++ b/backend/src/entity/entities/VLendingForSearchUser.ts
@@ -12,7 +12,7 @@ import { DataSource, ViewColumn, ViewEntity } from 'typeorm';
     .addSelect('bi.title', 'title')
     .addSelect('DATE_ADD(l.createdAt, INTERVAL 14 DAY)', 'duedate')
     .addSelect('CASE WHEN DATEDIFF(now(), DATE_ADD(l.createdAt, INTERVAL 14 DAY)) < 0 THEN 0 ELSE DATEDIFF(now(), DATE_ADD(l.createdAt, INTERVAL 14 DAY)) END', 'overDueDay')
-    .addSelect('(SELECT COUNT(r.id) FROM reservation r WHERE r.userId = l.userId)', 'reservedNum')
+    .addSelect('(SELECT COUNT(r.id) FROM reservation r WHERE r.bookInfoId = bi.id AND r.status = 0)', 'reservedNum')
     .from('lending', 'l')
     .where('l.returnedAt is NULL')
     .innerJoin('user', 'u', 'l.userId = u.id')

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -31,6 +31,11 @@ export const router = Router();
  *          description: 한 페이지에 들어올 검색결과 수
  *          schema:
  *            type: integer
+  *        - in: query
+ *          name: id
+ *          description: 검색할 유저의 id
+ *          schema:
+ *            type: integer
  *      responses:
  *        '200':
  *          description: 검색 결과를 반환한다.


### PR DESCRIPTION
### 작업사항 및 변경점
- v_lending_for_search_user.reservedNum을 select하는 방식 변경.
- /api/users/search?id=1568과 같이 user의 id를 query로 받을 수 있는 부분이 swagger에 누락되어 추가함.

### 목적
- 마이페이지에서 대출한 책의 예약수를 바르게 표기

### 스크린샷 (optional)

<img width="1000" alt="스크린샷 2023-03-08 오전 1 19 53" src="https://user-images.githubusercontent.com/30787477/223483527-aec17d9c-77c4-4d40-b70e-ed351331f4a4.png">

마이페이지에서 대출한 책의 예약수가 항상 최대치(해당 책의 개수)로 표기됨