### PR TITLE
FIX: 최초 인트라 로그인시 버그

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -30,8 +30,7 @@ export const getToken = async (req: Request, res: Response, next: NextFunction):
       // 회원가입
       try {
         const email = `${nickName}@student.42seoul.kr`;
-        const password = Math.random().toString(36).slice(2); // 랜덤 비밀번호 설정
-        await usersService.createUser(String(email), await bcrypt.hash(String(password), 10));
+        await usersService.createUser(String(email), await bcrypt.hash(String(email), 10));
         const newUser: { items: models.User[] } = await usersService.searchUserByEmail(email);
         await authService.updateAuthenticationUser(newUser.items[0].id, id, nickName);
         await updateSlackIdByUserId(newUser.items[0].id);

--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -134,7 +134,7 @@ export default class UsersRepository extends Repository<User> {
   async insertUser(email: string, password: string) {
     const penaltyEndDate = new Date(0);
     penaltyEndDate.setDate(penaltyEndDate.getDate() - 1);
-    this.insert({
+    await this.insert({
       email,
       password,
       penaltyEndDate: formatDate(penaltyEndDate),


### PR DESCRIPTION
### 개요
최초 인트라 로그인시 password를 email으로 설정
최초 인트라 로그인시 인증이 되지 않던 버그 픽스

### 개선사항
사용자가 일반로그인으로 바로 로그인 할 수 있도록, 최초 비번을 ID와 같게(${intraID}@student.42seoul.kr)으로 설정

### 버그픽스
`insertUser()`함수에 await추가,
 async함수로 만들어두었지만 내부적으로 await가 없어서 순차적으로 실행되고 있지 않았음


