### PR TITLE
FEAT: 재고 확인 기준을 15일 이내에 체크로 변경.

### DIFF
--- a/backend/src/stocks/stocks.repository.ts
+++ b/backend/src/stocks/stocks.repository.ts
@@ -2,7 +2,7 @@ import {
   LessThan,
   QueryRunner, Repository,
 } from 'typeorm';
-import { startOfDay } from 'date-fns';
+import { startOfDay, addDays } from 'date-fns';
 import jipDataSource from '../app-data-source';
 import book from '../entity/entities/Book';
 import VStock from '../entity/entities/VStock';
@@ -27,7 +27,7 @@ class StocksRepository extends Repository<book> {
     const [items, totalItems] = await this.vStock
       .findAndCount({
         where: {
-          updatedAt: LessThan(today),
+          updatedAt: LessThan(addDays(today, -15)),
         },
         take: limit,
         skip: limit * page,


### PR DESCRIPTION
### 개요
-재고 확인을 당일 해야하는 문제가 생겼음

### 작업 사항
- 오프라인으로 책 재고 업데이트 후 15일까지 업데이트 내용이 적용되도록 변경
- 
### 변경점
- updatedAt 체크하는 기준을 15일 이전으로 변경
