### PR TITLE
BUG: 이미 bookInfo가 존재하는 책을 추가할 때, bookInfoId가 입력되지 않던 버그 수정

### DIFF
--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -107,6 +107,8 @@ export const createBook = async (book: CreateBookInfo) => {
       const categoryId = book.categoryId === undefined ? '' : book.categoryId;
       recommendPrimaryNum = await booksRepository.getNewCallsignPrimaryNum(categoryId);
     } else {
+      const bookInfoId = await booksRepository.getBookList(isbn, 1, 0);
+      book.infoId = bookInfoId[0].bookInfoId;
       const nums = await booksRepository.getOldCallsignNums(categoryAlphabet);
       recommendPrimaryNum = nums.recommendPrimaryNum;
       recommendCopyNum = nums.recommendCopyNum * 1 + 1;


### PR DESCRIPTION
### 개요
이미  bookInfo가 존재하는 책을 추가할 때, bookInfoId가 입력되지 않아 DB에 Insert되지 않던 버그 수정

### 작업 사항
bookInfo가 존재하는 경우, book.infoId에 bookInfoId 추가

### 변경점
- `books.service.ts` 내 bookInfoId를 book.infoId에 할당