### PR TITLE
DOCS: 태그 조회 api 추가

### DIFF
--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -861,6 +861,98 @@ router
   .get('/info/:bookInfoId/like', authValidateDefaultNullUser(roleSet.all), getLikeInfo);
 
 router
+  /**
+ * @openapi
+ * /api/books/info/{bookInfoId}/tags:
+ *    get:
+ *      tags:
+ *      - tags
+ *      summary: 도서 별 태그 조회
+ *      description: 도서 별 태그 정보를 검색하여 보여준다.
+ *      parameters:
+ *      - name: bookInfoId
+ *        in: query
+ *        description: 태그를 조회할 도서의 bookInfoId
+ *        schema:
+ *          type: integer
+ *          example: 42
+ *      responses:
+ *        '200':
+ *          description: 대출 기록을 반환한다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  items:
+ *                    description: 검색된 태그들의 목록
+ *                    type: array
+ *                    items:
+ *                      type: object
+ *                      properties:
+ *                        id:
+ *                          description: 태그 고유 id
+ *                          type: integer
+ *                        content:
+ *                          description: 태그의 내용
+ *                          type: string
+ *                        login:
+ *                          description: 태그를 작성한 카뎃의 인트라 id
+ *                          type: string
+ *                        bookInfoId:
+ *                          description: 태그가 작성된 책의 bookInfoId
+ *                          type: integer
+ *                        count:
+ *                          description: 태그의 개수
+ *                          type: integer
+ *                        createdAt:
+ *                          description: 태그가 작성된 날짜
+ *                          type: string
+ *                          format: date
+ *                        updatedAt:
+ *                          description: 태그가 수정된 날짜
+ *                          type: string
+ *                          format: date
+ *                    example:
+ *                      - id: 0
+ *                        content: 1서클_추천_책
+ *                        login: yena, jang-cho, chanheki
+ *                        bookInfoId: 42
+ *                        count: 3
+ *                        createdAt: 2023.03.26
+ *                        updatedAt: 2023.03.27
+ *                      - id: 1
+ *                        content: libft
+ *                        login: yena, jang-cho
+ *                        bookInfoId: 42
+ *                        count: 2
+ *                        createdAt: 2023.03.26
+ *                        updatedAt: 2023.03.27
+ *                      - id: 42
+ *                        content: C_기본
+ *                        login: yena
+ *                        bookInfoId: 42
+ *                        count: 1
+ *                        createdAt: 2023.03.27
+ *                        updatedAt: 2023.03.27
+ *                  meta:
+ *                    description: 태그 조회 결과에 대한 요약 정보
+ *                    type: object
+ *                    properties:
+ *                      totalItems:
+ *                        description: 전체 태그 검색 결과 건수
+ *                        type: integer
+ *                        example: 3
+ *        '400':
+ *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+ *        '401':
+ *          description: 대출을 조회할 권한이 없는 사용자
+ *        '500':
+ *          description: db 에러
+ */
+  .get('/info/{bookInfoId}/tags', authValidate(roleSet.all) /* , getTagInfo */);
+
+router
 /**
  * @openapi
  * /api/books/update:

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -861,62 +861,6 @@ router
   .get('/info/:bookInfoId/like', authValidateDefaultNullUser(roleSet.all), getLikeInfo);
 
 router
-  /**
- * @openapi
- * /api/books/info/{bookInfoId}/tags:
- *    get:
- *      tags:
- *      - tags
- *      summary: 도서 별 태그 조회
- *      description: 도서 별 슈퍼 태그 정보를 검색하여 보여준다.
- *      parameters:
- *      - name: bookInfoId
- *        in: query
- *        description: 슈퍼 태그를 조회할 도서의 bookInfoId
- *        schema:
- *          type: integer
- *          example: 42
- *      responses:
- *        '200':
- *          description: 슈퍼 태그 목록을 반환한다.
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  items:
- *                    description: 검색된 슈퍼 태그들의 목록
- *                    type: array
- *                    items:
- *                      type: object
- *                      properties:
- *                        id:
- *                          description: 슈퍼 태그 고유 id
- *                          type: integer
- *                        content:
- *                          description: 슈퍼 태그의 내용
- *                          type: string
- *                        login:
- *                          description: 슈퍼 태그에 병합된 서브 태그를 작성한 카뎃의 인트라 id
- *                          type: list
- *                    example:
- *                      - id: 0
- *                        content: 1서클_추천_책
- *                        login: yena, jang-cho, chanheki
- *                      - id: 1
- *                        content: libft
- *                        login: yena, jang-cho
- *                      - id: 42
- *                        content: C
- *                        login: yena
- *        '400':
- *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
- *        '500':
- *          description: db 에러
- */
-  .get('/info/{bookInfoId}/tags', authValidate(roleSet.all) /* , getTagInfo */);
-
-router
 /**
  * @openapi
  * /api/books/update:

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -945,8 +945,6 @@ router
  *                        example: 3
  *        '400':
  *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
- *        '401':
- *          description: 대출을 조회할 권한이 없는 사용자
  *        '500':
  *          description: db 에러
  */

--- a/backend/src/routes/books.routes.ts
+++ b/backend/src/routes/books.routes.ts
@@ -868,81 +868,47 @@ router
  *      tags:
  *      - tags
  *      summary: 도서 별 태그 조회
- *      description: 도서 별 태그 정보를 검색하여 보여준다.
+ *      description: 도서 별 슈퍼 태그 정보를 검색하여 보여준다.
  *      parameters:
  *      - name: bookInfoId
  *        in: query
- *        description: 태그를 조회할 도서의 bookInfoId
+ *        description: 슈퍼 태그를 조회할 도서의 bookInfoId
  *        schema:
  *          type: integer
  *          example: 42
  *      responses:
  *        '200':
- *          description: 대출 기록을 반환한다.
+ *          description: 슈퍼 태그 목록을 반환한다.
  *          content:
  *            application/json:
  *              schema:
  *                type: object
  *                properties:
  *                  items:
- *                    description: 검색된 태그들의 목록
+ *                    description: 검색된 슈퍼 태그들의 목록
  *                    type: array
  *                    items:
  *                      type: object
  *                      properties:
  *                        id:
- *                          description: 태그 고유 id
+ *                          description: 슈퍼 태그 고유 id
  *                          type: integer
  *                        content:
- *                          description: 태그의 내용
+ *                          description: 슈퍼 태그의 내용
  *                          type: string
  *                        login:
- *                          description: 태그를 작성한 카뎃의 인트라 id
- *                          type: string
- *                        bookInfoId:
- *                          description: 태그가 작성된 책의 bookInfoId
- *                          type: integer
- *                        count:
- *                          description: 태그의 개수
- *                          type: integer
- *                        createdAt:
- *                          description: 태그가 작성된 날짜
- *                          type: string
- *                          format: date
- *                        updatedAt:
- *                          description: 태그가 수정된 날짜
- *                          type: string
- *                          format: date
+ *                          description: 슈퍼 태그에 병합된 서브 태그를 작성한 카뎃의 인트라 id
+ *                          type: list
  *                    example:
  *                      - id: 0
  *                        content: 1서클_추천_책
  *                        login: yena, jang-cho, chanheki
- *                        bookInfoId: 42
- *                        count: 3
- *                        createdAt: 2023.03.26
- *                        updatedAt: 2023.03.27
  *                      - id: 1
  *                        content: libft
  *                        login: yena, jang-cho
- *                        bookInfoId: 42
- *                        count: 2
- *                        createdAt: 2023.03.26
- *                        updatedAt: 2023.03.27
  *                      - id: 42
- *                        content: C_기본
+ *                        content: C
  *                        login: yena
- *                        bookInfoId: 42
- *                        count: 1
- *                        createdAt: 2023.03.27
- *                        updatedAt: 2023.03.27
- *                  meta:
- *                    description: 태그 조회 결과에 대한 요약 정보
- *                    type: object
- *                    properties:
- *                      totalItems:
- *                        description: 전체 태그 검색 결과 건수
- *                        type: integer
- *                        example: 3
  *        '400':
  *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
  *        '500':

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -8,7 +8,7 @@ export const router = Router();
 router
   /**
    * @openapi
-   * /api/tags:
+   * /api/tags/sub:
    *    get:
    *      tags:
    *      - tags
@@ -107,16 +107,16 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/tags', authValidate(roleSet.librarian) /* , searchSubTag */);
+  .get('/tags/sub', authValidate(roleSet.librarian) /* , searchSubTag */);
 
 router
   /**
    * @openapi
-   * /api/tags/super:
+   * /api/tags:
    *    get:
    *      tags:
    *      - tags
-   *      summary: 슈퍼 태그 목록을 가져온다.
+   *      summary: 메인 페이지의 슈퍼 태그 목록을 가져온다.
    *      description: 메인 페이지에서 보여줄 슈퍼 태그 정보를 검색하여 보여준다.
    *      parameters:
    *      responses:
@@ -151,7 +151,7 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/tags/super', authValidate(roleSet.all) /* , searchSubTag */);
+  .get('/tags', authValidate(roleSet.all) /* , searchSubTag */);
 
 router
   /**

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -12,19 +12,19 @@ router
    *    get:
    *      tags:
    *      - tags
-   *      summary: 태그 목록을 가져온다.
-   *      description: 슈퍼/서브/디폴트 태그 정보를 검색하여 보여준다.
+   *      summary: 서브/디폴트 태그 정보를 검색한다.
+   *      description: 서브/디폴트 태그 정보를 검색한다. 이는 태그 관리 페이지에서 사용한다.
    *      parameters:
    *        - name: page
    *          in: query
-   *          description: 검색 결과의 페이지
+   *          description: 검색 결과의 페이지.
    *          schema:
    *            type: integer
    *            default: 1
-   *            example: 3
+   *            example: 1
    *        - name: limit
    *          in: query
-   *          description: 검색 결과 한 페이지당 보여줄 결과물의 개수
+   *          description: 검색 결과 한 페이지당 보여줄 결과물의 개수.
    *          schema:
    *            type: integer
    *            default: 10
@@ -32,24 +32,19 @@ router
    *        - name: visibility
    *          in: query
    *          description: 공개 및 비공개 여부로, public 이면 공개, private 이면 비공개 서브 태그만 가져온다.
+   *          required: true
    *          schema:
    *            type: string
    *            default: public
-   *            example: private
-   *        - name: type
+   *            example: public
+   *            enum: [public, private]
+   *        - name: title
    *          in: query
-   *          description: 태그의 타입으로, super, sub, default 중 하나를 입력한다.
+   *          description: 검색할 도서의 제목. 검색 결과는 도서 제목에 해당하는 태그들을 반환한다.
    *          schema:
    *            type: string
-   *            default: super
-   *            example: super
-   *            enum: [super, sub, default]
-   *        - name: bookInfoId
-   *          in: query
-   *          description: 태그가 등록된 도서의 infoId
-   *          schema:
-   *            type: integer
-   *            example: 1
+   *            example: 깐깐하게 배우는 C
+   *            nullable: true
    *      responses:
    *        '200':
    *          description: 슈퍼/서브/디폴트 태그들을 반환한다.
@@ -88,6 +83,30 @@ router
    *                          description: 슈퍼 태그의 내용
    *                          type: string
    *                          example: 1서클_추천_책
+   *                  meta:
+   *                    description: 모든 태그 수와 관련된 정보
+   *                    type: object
+   *                    properties:
+   *                      totalItems:
+   *                        description: 전체 검색 결과 수
+   *                        type: integer
+   *                        example: 1
+   *                      itemCount:
+   *                        description: 현재 페이지 검색 결과 수
+   *                        type: integer
+   *                        example: 1
+   *                      itemsPerPage:
+   *                        description: 페이지 당 검색 결과 수
+   *                        type: integer
+   *                        example: 10
+   *                      totalPages:
+   *                        description: 전체 결과 페이지 수
+   *                        type: integer
+   *                        example: 1
+   *                      currentPage:
+   *                        description: 현재 페이지
+   *                        type: integer
+   *                        example: 1
    *          '400':
    *            description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
    *          '401':
@@ -105,8 +124,8 @@ router
    *      tags:
    *      - tags
    *      summary: 슈퍼 태그에 속한 서브 태그 목록을 가져온다.
-   *      description: 태그를 병합하기 위한 슈퍼 태그(노출되는 태그),
-   *                   서브 태그(노출되지 않는 태그)를 가져온다.
+   *      description: superTagId에 해당하는 슈퍼 태그에 속한 서브 태그 목록을 가져온다. 태그 병합 페이지에서 슈퍼 태그의
+   *                   서브 태그를 가져올 때 사용한다.
    *      parameters:
    *        - in: path
    *          name: superTagId
@@ -157,13 +176,13 @@ router
 router
   /**
    * @openapi
-   * /api/{bookInfoId}/tags:
+   * /api/tags/{bookInfoId}:
    *    get:
    *      tags:
    *      - tags
    *      summary: 도서에 등록된 슈퍼 태그, 디폴트 태그 목록을 가져온다.
-   *      description: 태그를 병합하기 위한 슈퍼 태그(노출되는 태그),
-   *                   디폴트 태그(노출되지 않고 분류되지 않은 태그)를 가져온다.
+   *      description: 슈퍼 태그(노출되는 태그), 디폴트 태그(노출되지 않고 분류되지 않은 태그)를 가져온다.
+   *                   이는 도서 상세 페이지 및 태그 병합 페이지에서 사용된다.
    *      parameters:
    *        - in: path
    *          name: bookInfoId

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -112,6 +112,50 @@ router
 router
   /**
    * @openapi
+   * /api/tags/super:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 슈퍼 태그 목록을 가져온다.
+   *      description: 메인 페이지에서 보여줄 슈퍼 태그 정보를 검색하여 보여준다.
+   *      parameters:
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 슈퍼 태그 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        title:
+   *                          description: 슈퍼 태그가 등록된 도서의 제목
+   *                          type: string
+   *                        content:
+   *                          description: 슈퍼 태그의 내용
+   *                          type: string
+   *                    example:
+   *                      - title: 깐깐하게 배우는 C
+   *                        content: 1서클_추천_책
+   *                      - title: 나는 LINE 개발자입니다
+   *                        content: 커리어
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/tags/super', authValidate(roleSet.all) /* , searchSubTag */);
+
+router
+  /**
+   * @openapi
    * /api/tags/merge:
    *    get:
    *      tags:

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -128,40 +128,44 @@ router
    *              schema:
    *                type: object
    *                properties:
-   *                  superTags:
-   *                    description: 슈퍼 태그 목록
-   *                    type: list
-   *                    items:
-   *                      type: object
-   *                      properties:
-   *                        id:
-   *                          description: 슈퍼 태그 고유 id
-   *                          type: integer
-   *                        content:
-   *                          description: 슈퍼 태그의 내용
-   *                          type: string
-   *                    example:
-   *                      - id: 0
-   *                        content: 파이썬
-   *                      - id: 42
-   *                        content: Python
-   *                  defaultTags:
-   *                    description: 디폴트 태그 목록
-   *                    type: list
-   *                    items:
-   *                      type: object
-   *                      properties:
-   *                        id:
-   *                          description: 디폴트 태그 고유 id
-   *                          type: integer
-   *                        content:
-   *                          description: 디폴트 태그의 내용
-   *                          type: string
-   *                    example:
-   *                      - id: 0
-   *                        content: yena가_추천하는
-   *                      - id: 42
-   *                        content: 멋지다_집현전
+   *                  items:
+   *                    description: 슈퍼 태그, 디폴트 태그 목록
+   *                    type: object
+   *                    properties:
+   *                      superTags:
+   *                        description: 슈퍼 태그 목록
+   *                        type: array
+   *                        items:
+   *                          type: object
+   *                          properties:
+   *                            id:
+   *                              description: 슈퍼 태그 고유 id
+   *                              type: integer
+   *                            content:
+   *                              description: 슈퍼 태그 내용
+   *                              type: string
+   *                        example:
+   *                          - id: 0
+   *                            content: 1서클_추천_책
+   *                          - id: 42
+   *                            content: 커리어
+   *                      defaultTags:
+   *                        description: 디폴트 태그 목록
+   *                        type: array
+   *                        items:
+   *                          type: object
+   *                          properties:
+   *                            id:
+   *                              description: 디폴트 태그 고유 id
+   *                              type: integer
+   *                            content:
+   *                              description: 디폴트 태그 내용
+   *                              type: string
+   *                        example:
+   *                          - id: 0
+   *                            content: yena가_추천하는
+   *                          - id: 42
+   *                            content: 마법같은_파이썬
    *        '400':
    *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
    *        '401':

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -8,6 +8,50 @@ export const router = Router();
 router
   /**
    * @openapi
+   * /api/tags:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 메인 페이지의 슈퍼 태그 목록을 가져온다.
+   *      description: 메인 페이지에서 보여줄 슈퍼 태그 정보를 검색하여 보여준다.
+   *      parameters:
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 슈퍼 태그 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        title:
+   *                          description: 슈퍼 태그가 등록된 도서의 제목
+   *                          type: string
+   *                        content:
+   *                          description: 슈퍼 태그의 내용
+   *                          type: string
+   *                    example:
+   *                      - title: 깐깐하게 배우는 C
+   *                        content: 1서클_추천_책
+   *                      - title: 나는 LINE 개발자입니다
+   *                        content: 커리어
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/tags', authValidate(roleSet.all) /* , searchSubTag */);
+
+router
+  /**
+   * @openapi
    * /api/tags/sub:
    *    get:
    *      tags:
@@ -112,50 +156,6 @@ router
 router
   /**
    * @openapi
-   * /api/tags:
-   *    get:
-   *      tags:
-   *      - tags
-   *      summary: 메인 페이지의 슈퍼 태그 목록을 가져온다.
-   *      description: 메인 페이지에서 보여줄 슈퍼 태그 정보를 검색하여 보여준다.
-   *      parameters:
-   *      responses:
-   *        '200':
-   *          description: 슈퍼 태그들을 반환한다.
-   *          content:
-   *            application/json:
-   *              schema:
-   *                type: object
-   *                properties:
-   *                  items:
-   *                    description: 슈퍼 태그 목록
-   *                    type: array
-   *                    items:
-   *                      type: object
-   *                      properties:
-   *                        title:
-   *                          description: 슈퍼 태그가 등록된 도서의 제목
-   *                          type: string
-   *                        content:
-   *                          description: 슈퍼 태그의 내용
-   *                          type: string
-   *                    example:
-   *                      - title: 깐깐하게 배우는 C
-   *                        content: 1서클_추천_책
-   *                      - title: 나는 LINE 개발자입니다
-   *                        content: 커리어
-   *        '400':
-   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
-   *        '401':
-   *          description: 태그 기록을 조회할 권한이 없는 사용자
-   *        '500':
-   *          description: db 에러
-   */
-  .get('/tags', authValidate(roleSet.all) /* , searchSubTag */);
-
-router
-  /**
-   * @openapi
    * /api/tags/merge:
    *    get:
    *      tags:
@@ -218,3 +218,60 @@ router
    *          description: db 에러
    */
   .get('/tags/merge', authValidate(roleSet.librarian) /* , searchSubTag */);
+
+router
+  /**
+   * @openapi
+   * /api/tags/{superTagId}/sub:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 슈퍼 태그에 속한 서브 태그 목록을 가져온다.
+   *      description: 태그를 병합하기 위한 슈퍼 태그(노출되는 태그),
+   *                   서브 태그(노출되지 않는 태그)를 가져온다.
+   *      parameters:
+   *        - in: path
+   *          name: superTagId
+   *          description: 서브 태그를 조회할 슈퍼 태그의 id
+   *          required: true
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그에 속한 서브 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 슈퍼 태그에 속한 서브 태그 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        id:
+   *                          description: 서브 태그 고유 id
+   *                          type: integer
+   *                        content:
+   *                          description: 서브 태그의 내용
+   *                          type: string
+   *                        login:
+   *                          description: 서브 태그를 작성한 카뎃의 인트라 id
+   *                          type: string
+   *                    example:
+   *                    - id: 0
+   *                      content: 도커_쿠버네티스
+   *                      login: yena
+   *                    - id: 42
+   *                      content: 도커
+   *                      login: yena
+   *                    - id: 50
+   *                      content: 도커
+   *                      login: jang-cho
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/api/tags/{superTagId}/sub', authValidate(roleSet.librarian) /* , searchSubTag */);

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -105,21 +105,15 @@ router
    *                        login:
    *                          description: 서브 태그를 작성한 카뎃의 인트라 id
    *                          type: string
-   *                        createdAt:
-   *                          description: 태그가 작성된 날짜
-   *                          type: string
-   *                          format: date
    *                    example:
    *                      - id: 0
    *                        title: 깐깐하게 배우는 C
    *                        content: 1서클_추천_책
    *                        login: yena
-   *                        createdAt: 2023.03.27
    *                      - id: 42
    *                        title: 나는 LINE 개발자입니다
    *                        content: 커리어
    *                        login: yena
-   *                        createdAt: 2023.03.27
    *                  meta:
    *                    description: 태그 조회 결과에 대한 요약 정보
    *                    type: object

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -67,19 +67,15 @@ router
    *                          format: date
    *                    example:
    *                      - id: 0
+   *                        title: 깐깐하게 배우는 C
    *                        content: 1서클_추천_책
    *                        login: yena
-   *                        bookInfoId: 1
-   *                        count: 1
    *                        createdAt: 2023.03.27
-   *                        updatedAt: 2023.03.27
    *                      - id: 42
-   *                        content: minirt
-   *                        login: yena, jang-cho
-   *                        bookInfoId: 42
-   *                        count: 2
+   *                        title: 나는 LINE 개발자입니다
+   *                        content: 커리어
+   *                        login: yena
    *                        createdAt: 2023.03.27
-   *                        updatedAt: 2023.03.27
    *                  meta:
    *                    description: 태그 조회 결과에 대한 요약 정보
    *                    type: object
@@ -111,7 +107,7 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/tags', authValidate(roleSet.librarian) /* , searchSubTag */);
+  .get('/tags', authValidate(roleSet.all) /* , searchSubTag */);
 
 router
   /**

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -173,4 +173,4 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/tags', authValidate(roleSet.librarian) /* , searchSubTag */);
+  .get('/tags/merge', authValidate(roleSet.librarian) /* , searchSubTag */);

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -73,12 +73,13 @@ router
    *          type: integer
    *          default: 10
    *          example: 10
-   *      - name: private
+   *      - name: visibility
    *        in: query
-   *        description: 공개 및 비공개 여부로, 1이면 공개, 0이면 비공개 서브 태그만 가져온다.
+   *        description: 공개 및 비공개 여부로, public 이면 공개, private 이면 비공개 서브 태그만 가져온다.
    *        schema:
-   *          type: integer
-   *          example: 1
+   *          type: string
+   *          default: public
+   *          example: private
    *      responses:
    *        '200':
    *          description: 서브 태그들을 반환한다.

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -8,12 +8,12 @@ export const router = Router();
 router
   /**
    * @openapi
-   * /api/tags/search:
+   * /api/tags:
    *    get:
    *      tags:
    *      - tags
-   *      summary: 전체 태그 조회
-   *      description: 태그 정보를 검색하여 보여준다.
+   *      summary: 서브 태그 목록을 가져온다.
+   *      description: 태그 관리 페이지에서 보여줄 서브 태그 정보를 검색하여 보여준다.
    *      parameters:
    *      - name: page
    *        in: query
@@ -27,62 +27,42 @@ router
    *        description: 검색 결과 한 페이지당 보여줄 결과물의 개수
    *        schema:
    *          type: integer
-   *          default: 5
-   *          example: 3
-   *      - name: sort
+   *          default: 10
+   *          example: 10
+   *      - name: private
    *        in: query
-   *        description: 검색 결과를 정렬할 기준
+   *        description: 공개 및 비공개 여부로, 1이면 공개, 0이면 비공개 서브 태그만 가져온다.
    *        schema:
-   *          type: string
-   *          enum: [new, old]
-   *          default: new
-   *      - name: query
-   *        in: query
-   *        description: 태그 목록에서 검색할 단어, 검색 가능한 필드 [user, title, bookInfoId]
-   *        schema:
-   *          type: string
-   *          example: yena
-   *      - name: type
-   *        in: query
-   *        description: query를 조회할 항목
-   *        schema:
-   *          type: string
-   *          enum: [user, title, bookInfoId]
+   *          type: integer
+   *          example: 1
    *      responses:
    *        '200':
-   *          description: 태그 기록을 반환한다.
+   *          description: 서브 태그들을 반환한다.
    *          content:
    *            application/json:
    *              schema:
    *                type: object
    *                properties:
    *                  items:
-   *                    description: 검색된 태그들의 목록
+   *                    description: 서브 태그 목록
    *                    type: array
    *                    items:
    *                      type: object
    *                      properties:
    *                        id:
-   *                          description: 태그 고유 id
+   *                          description: 서브 태그 고유 id
    *                          type: integer
+   *                        title:
+   *                          description: 서브 태그가 등록된 도서의 제목
+   *                          type: string
    *                        content:
-   *                          description: 태그의 내용
+   *                          description: 서브 태그의 내용
    *                          type: string
    *                        login:
-   *                          description: 태그를 작성한 카뎃의 인트라 id
+   *                          description: 서브 태그를 작성한 카뎃의 인트라 id
    *                          type: string
-   *                        bookInfoId:
-   *                          description: 태그가 작성된 책의 bookInfoId
-   *                          type: integer
-   *                        count:
-   *                          description: 태그의 개수
-   *                          type: integer
    *                        createdAt:
    *                          description: 태그가 작성된 날짜
-   *                          type: string
-   *                          format: date
-   *                        updatedAt:
-   *                          description: 태그가 수정된 날짜
    *                          type: string
    *                          format: date
    *                    example:
@@ -131,4 +111,4 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/search', authValidate(roleSet.librarian) /* , search */);
+  .get('/tags', authValidate(roleSet.librarian) /* , searchSubTag */);

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -12,207 +12,90 @@ router
    *    get:
    *      tags:
    *      - tags
-   *      summary: 메인 페이지의 슈퍼 태그 목록을 가져온다.
-   *      description: 메인 페이지에서 보여줄 슈퍼 태그 정보를 검색하여 보여준다.
+   *      summary: 태그 목록을 가져온다.
+   *      description: 슈퍼/서브/디폴트 태그 정보를 검색하여 보여준다.
    *      parameters:
+   *        - name: page
+   *          in: query
+   *          description: 검색 결과의 페이지
+   *          schema:
+   *            type: integer
+   *            default: 1
+   *            example: 3
+   *        - name: limit
+   *          in: query
+   *          description: 검색 결과 한 페이지당 보여줄 결과물의 개수
+   *          schema:
+   *            type: integer
+   *            default: 10
+   *            example: 10
+   *        - name: visibility
+   *          in: query
+   *          description: 공개 및 비공개 여부로, public 이면 공개, private 이면 비공개 서브 태그만 가져온다.
+   *          schema:
+   *            type: string
+   *            default: public
+   *            example: private
+   *        - name: type
+   *          in: query
+   *          description: 태그의 타입으로, super, sub, default 중 하나를 입력한다.
+   *          schema:
+   *            type: string
+   *            default: super
+   *            example: super
+   *            enum: [super, sub, default]
+   *        - name: bookInfoId
+   *          in: query
+   *          description: 태그가 등록된 도서의 infoId
+   *          schema:
+   *            type: integer
+   *            example: 1
    *      responses:
    *        '200':
-   *          description: 슈퍼 태그들을 반환한다.
+   *          description: 슈퍼/서브/디폴트 태그들을 반환한다.
    *          content:
    *            application/json:
    *              schema:
    *                type: object
    *                properties:
    *                  items:
-   *                    description: 슈퍼 태그 목록
+   *                    description: 태그 목록
    *                    type: array
    *                    items:
    *                      type: object
    *                      properties:
+   *                        bookInfoId:
+   *                          description: 태그가 등록된 도서의 infoId
+   *                          type: integer
+   *                          example: 1
    *                        title:
-   *                          description: 슈퍼 태그가 등록된 도서의 제목
+   *                          description: 태그가 등록된 도서의 제목
    *                          type: string
+   *                          example: 깐깐하게 배우는 C
+   *                        id:
+   *                          description: 태그 고유 id
+   *                          type: integer
+   *                          example: 1
+   *                        createdAt:
+   *                          description: 태그가 등록된 시간
+   *                          type: string
+   *                          example: 2023-04-12
+   *                        nickname:
+   *                          description: 태그를 작성한 카뎃의 닉네임
+   *                          type: string
+   *                          example: yena
    *                        content:
    *                          description: 슈퍼 태그의 내용
    *                          type: string
-   *                    example:
-   *                      - title: 깐깐하게 배우는 C
-   *                        content: 1서클_추천_책
-   *                      - title: 나는 LINE 개발자입니다
-   *                        content: 커리어
-   *        '400':
-   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
-   *        '401':
-   *          description: 태그 기록을 조회할 권한이 없는 사용자
-   *        '500':
-   *          description: db 에러
+   *                          example: 1서클_추천_책
+   *          '400':
+   *            description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *          '401':
+   *            description: 태그 기록을 조회할 권한이 없는 사용자
+   *          '500':
+   *            description: db 에러
    */
   .get('/tags', authValidate(roleSet.all) /* , searchSubTag */);
-
-router
-  /**
-   * @openapi
-   * /api/tags/sub:
-   *    get:
-   *      tags:
-   *      - tags
-   *      summary: 서브 태그 목록을 가져온다.
-   *      description: 태그 관리 페이지에서 보여줄 서브 태그 정보를 검색하여 보여준다.
-   *      parameters:
-   *      - name: page
-   *        in: query
-   *        description: 검색 결과의 페이지
-   *        schema:
-   *          type: integer
-   *          default: 1
-   *          example: 3
-   *      - name: limit
-   *        in: query
-   *        description: 검색 결과 한 페이지당 보여줄 결과물의 개수
-   *        schema:
-   *          type: integer
-   *          default: 10
-   *          example: 10
-   *      - name: visibility
-   *        in: query
-   *        description: 공개 및 비공개 여부로, public 이면 공개, private 이면 비공개 서브 태그만 가져온다.
-   *        schema:
-   *          type: string
-   *          default: public
-   *          example: private
-   *      responses:
-   *        '200':
-   *          description: 서브 태그들을 반환한다.
-   *          content:
-   *            application/json:
-   *              schema:
-   *                type: object
-   *                properties:
-   *                  items:
-   *                    description: 서브 태그 목록
-   *                    type: array
-   *                    items:
-   *                      type: object
-   *                      properties:
-   *                        id:
-   *                          description: 서브 태그 고유 id
-   *                          type: integer
-   *                        title:
-   *                          description: 서브 태그가 등록된 도서의 제목
-   *                          type: string
-   *                        content:
-   *                          description: 서브 태그의 내용
-   *                          type: string
-   *                        login:
-   *                          description: 서브 태그를 작성한 카뎃의 인트라 id
-   *                          type: string
-   *                    example:
-   *                      - id: 0
-   *                        title: 깐깐하게 배우는 C
-   *                        content: 1서클_추천_책
-   *                        login: yena
-   *                      - id: 42
-   *                        title: 나는 LINE 개발자입니다
-   *                        content: 커리어
-   *                        login: yena
-   *                  meta:
-   *                    description: 태그 조회 결과에 대한 요약 정보
-   *                    type: object
-   *                    properties:
-   *                      totalItems:
-   *                        description: 전체 태그 검색 결과 건수
-   *                        type: integer
-   *                        example: 2
-   *                      itemCount:
-   *                        description: 현재 페이지 검색 결과 수
-   *                        type: integer
-   *                        example: 2
-   *                      itemsPerPage:
-   *                        description: 페이지 당 검색 결과 수
-   *                        type: integer
-   *                        example: 2
-   *                      totalPages:
-   *                        description: 전체 결과 페이지 수
-   *                        type: integer
-   *                        example: 1
-   *                      currentPage:
-   *                        description: 현재 페이지
-   *                        type: integer
-   *                        example: 1
-   *        '400':
-   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
-   *        '401':
-   *          description: 태그 기록을 조회할 권한이 없는 사용자
-   *        '500':
-   *          description: db 에러
-   */
-  .get('/tags/sub', authValidate(roleSet.librarian) /* , searchSubTag */);
-
-router
-  /**
-   * @openapi
-   * /api/tags/merge:
-   *    get:
-   *      tags:
-   *      - tags
-   *      summary: 슈퍼 태그, 디폴트 태그 목록을 가져온다.
-   *      description: 태그를 병합하기 위한 슈퍼 태그(노출되는 태그),
-   *                   디폴트 태그(노출되지 않고 분류되지 않은 태그)를 가져온다.
-   *      parameters:
-   *      responses:
-   *        '200':
-   *          description: 슈퍼 태그, 디폴트 태그들을 반환한다.
-   *          content:
-   *            application/json:
-   *              schema:
-   *                type: object
-   *                properties:
-   *                  items:
-   *                    description: 슈퍼 태그, 디폴트 태그 목록
-   *                    type: object
-   *                    properties:
-   *                      superTags:
-   *                        description: 슈퍼 태그 목록
-   *                        type: array
-   *                        items:
-   *                          type: object
-   *                          properties:
-   *                            id:
-   *                              description: 슈퍼 태그 고유 id
-   *                              type: integer
-   *                            content:
-   *                              description: 슈퍼 태그 내용
-   *                              type: string
-   *                        example:
-   *                          - id: 0
-   *                            content: 1서클_추천_책
-   *                          - id: 42
-   *                            content: 커리어
-   *                      defaultTags:
-   *                        description: 디폴트 태그 목록
-   *                        type: array
-   *                        items:
-   *                          type: object
-   *                          properties:
-   *                            id:
-   *                              description: 디폴트 태그 고유 id
-   *                              type: integer
-   *                            content:
-   *                              description: 디폴트 태그 내용
-   *                              type: string
-   *                        example:
-   *                          - id: 0
-   *                            content: yena가_추천하는
-   *                          - id: 42
-   *                            content: 마법같은_파이썬
-   *        '400':
-   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
-   *        '401':
-   *          description: 태그 기록을 조회할 권한이 없는 사용자
-   *        '500':
-   *          description: db 에러
-   */
-  .get('/tags/merge', authValidate(roleSet.librarian) /* , searchSubTag */);
 
 router
   /**
@@ -269,4 +152,83 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/api/tags/{superTagId}/sub', authValidate(roleSet.librarian) /* , searchSubTag */);
+  .get('/tags/{superTagId}/sub', authValidate(roleSet.librarian) /* , searchSubTag */);
+
+router
+  /**
+   * @openapi
+   * /api/{bookInfoId}/tags:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 도서에 등록된 슈퍼 태그, 디폴트 태그 목록을 가져온다.
+   *      description: 태그를 병합하기 위한 슈퍼 태그(노출되는 태그),
+   *                   디폴트 태그(노출되지 않고 분류되지 않은 태그)를 가져온다.
+   *      parameters:
+   *        - in: path
+   *          name: bookInfoId
+   *          description: 태그를 조회할 도서의 infoId
+   *          required: true
+   *          schema:
+   *            type: integer
+   *            example: 1
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그, 디폴트 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 슈퍼 태그, 디폴트 태그 목록
+   *                    type: object
+   *                    properties:
+   *                      superTags:
+   *                        description: 슈퍼 태그 목록
+   *                        type: array
+   *                        items:
+   *                          type: object
+   *                          properties:
+   *                            id:
+   *                              description: 슈퍼 태그 고유 id
+   *                              type: integer
+   *                            content:
+   *                              description: 슈퍼 태그 내용
+   *                              type: string
+   *                            count:
+   *                              description: 슈퍼 태그에 속한 서브 태그 개수
+   *                              type: integer
+   *                              default: 1
+   *                        example:
+   *                          - id: 0
+   *                            content: 1서클_추천_책
+   *                            count: 3
+   *                          - id: 42
+   *                            content: 커리어
+   *                            count: 1
+   *                      defaultTags:
+   *                        description: 디폴트 태그 목록
+   *                        type: array
+   *                        items:
+   *                          type: object
+   *                          properties:
+   *                            id:
+   *                              description: 디폴트 태그 고유 id
+   *                              type: integer
+   *                            content:
+   *                              description: 디폴트 태그 내용
+   *                              type: string
+   *                        example:
+   *                          - id: 0
+   *                            content: yena가_추천하는
+   *                          - id: 42
+   *                            content: 마법같은_파이썬
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/tags/merge', authValidate(roleSet.librarian) /* , searchSubTag */);

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -1,0 +1,134 @@
+import { Router } from 'express';
+import authValidate from '../auth/auth.validate';
+import { roleSet } from '../auth/auth.type';
+
+export const path = '/tags';
+export const router = Router();
+
+router
+  /**
+   * @openapi
+   * /api/tags/search:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 전체 태그 조회
+   *      description: 태그 정보를 검색하여 보여준다.
+   *      parameters:
+   *      - name: page
+   *        in: query
+   *        description: 검색 결과의 페이지
+   *        schema:
+   *          type: integer
+   *          default: 1
+   *          example: 3
+   *      - name: limit
+   *        in: query
+   *        description: 검색 결과 한 페이지당 보여줄 결과물의 개수
+   *        schema:
+   *          type: integer
+   *          default: 5
+   *          example: 3
+   *      - name: sort
+   *        in: query
+   *        description: 검색 결과를 정렬할 기준
+   *        schema:
+   *          type: string
+   *          enum: [new, old]
+   *          default: new
+   *      - name: query
+   *        in: query
+   *        description: 태그 목록에서 검색할 단어, 검색 가능한 필드 [user, title, bookInfoId]
+   *        schema:
+   *          type: string
+   *          example: yena
+   *      - name: type
+   *        in: query
+   *        description: query를 조회할 항목
+   *        schema:
+   *          type: string
+   *          enum: [user, title, bookInfoId]
+   *      responses:
+   *        '200':
+   *          description: 태그 기록을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 검색된 태그들의 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        id:
+   *                          description: 태그 고유 id
+   *                          type: integer
+   *                        content:
+   *                          description: 태그의 내용
+   *                          type: string
+   *                        login:
+   *                          description: 태그를 작성한 카뎃의 인트라 id
+   *                          type: string
+   *                        bookInfoId:
+   *                          description: 태그가 작성된 책의 bookInfoId
+   *                          type: integer
+   *                        count:
+   *                          description: 태그의 개수
+   *                          type: integer
+   *                        createdAt:
+   *                          description: 태그가 작성된 날짜
+   *                          type: string
+   *                          format: date
+   *                        updatedAt:
+   *                          description: 태그가 수정된 날짜
+   *                          type: string
+   *                          format: date
+   *                    example:
+   *                      - id: 0
+   *                        content: 1서클_추천_책
+   *                        login: yena
+   *                        bookInfoId: 1
+   *                        count: 1
+   *                        createdAt: 2023.03.27
+   *                        updatedAt: 2023.03.27
+   *                      - id: 42
+   *                        content: minirt
+   *                        login: yena, jang-cho
+   *                        bookInfoId: 42
+   *                        count: 2
+   *                        createdAt: 2023.03.27
+   *                        updatedAt: 2023.03.27
+   *                  meta:
+   *                    description: 태그 조회 결과에 대한 요약 정보
+   *                    type: object
+   *                    properties:
+   *                      totalItems:
+   *                        description: 전체 태그 검색 결과 건수
+   *                        type: integer
+   *                        example: 2
+   *                      itemCount:
+   *                        description: 현재 페이지 검색 결과 수
+   *                        type: integer
+   *                        example: 2
+   *                      itemsPerPage:
+   *                        description: 페이지 당 검색 결과 수
+   *                        type: integer
+   *                        example: 2
+   *                      totalPages:
+   *                        description: 전체 결과 페이지 수
+   *                        type: integer
+   *                        example: 1
+   *                      currentPage:
+   *                        description: 현재 페이지
+   *                        type: integer
+   *                        example: 1
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/search', authValidate(roleSet.librarian) /* , search */);

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -107,7 +107,7 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/tags', authValidate(roleSet.all) /* , searchSubTag */);
+  .get('/tags', authValidate(roleSet.librarian) /* , searchSubTag */);
 
 router
   /**

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -112,3 +112,65 @@ router
    *          description: db 에러
    */
   .get('/tags', authValidate(roleSet.librarian) /* , searchSubTag */);
+
+router
+  /**
+   * @openapi
+   * /api/tags/merge:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 슈퍼 태그, 디폴트 태그 목록을 가져온다.
+   *      description: 태그를 병합하기 위한 슈퍼 태그(노출되는 태그),
+   *                   디폴트 태그(노출되지 않고 분류되지 않은 태그)를 가져온다.
+   *      parameters:
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그, 디폴트 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  superTags:
+   *                    description: 슈퍼 태그 목록
+   *                    type: list
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        id:
+   *                          description: 슈퍼 태그 고유 id
+   *                          type: integer
+   *                        content:
+   *                          description: 슈퍼 태그의 내용
+   *                          type: string
+   *                    example:
+   *                      - id: 0
+   *                        content: 파이썬
+   *                      - id: 42
+   *                        content: Python
+   *                  defaultTags:
+   *                    description: 디폴트 태그 목록
+   *                    type: list
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        id:
+   *                          description: 디폴트 태그 고유 id
+   *                          type: integer
+   *                        content:
+   *                          description: 디폴트 태그의 내용
+   *                          type: string
+   *                    example:
+   *                      - id: 0
+   *                        content: yena가_추천하는
+   *                      - id: 42
+   *                        content: 멋지다_집현전
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/tags', authValidate(roleSet.librarian) /* , searchSubTag */);


### PR DESCRIPTION
### 개요
태그 조회 api 추가

### 작업 사항
- 전체 태그 조회 API 추가
- 도서 별 태그 조회 API 추가
- [x] 관리 페이지 도서별 태그 조회 시, 공개/비공개 여부도 가져오게 함, 삭제와는 별도의 기능

### 변경점
- `routes/tags.routes.ts` 추가
- `routes/books.routes.ts`에 태그 조회 API 추가

### 목적
- 태그 조회 기능 구현

### 스크린샷 (optional)
