### PR TITLE
DOCS: 태그 수정 API 추가

### DIFF
--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -7,15 +7,15 @@ export const router = Router();
 
 /**
  * @openapi
- * /api/tags/{id}:
+ * /api/tags/{superTagId}:
  *    patch:
- *      description: 태그를 수정한다.
+ *      description: 슈퍼 태그를 수정한다.
  *      tags:
  *        - tags
  *      parameters:
  *        - in: path
- *          name: id
- *          description: 변경할 태그의 id 값
+ *          name: superTagId
+ *          description: 변경할 슈퍼 태그의 id 값
  *          required: true
  *          schema:
  *            type: integer
@@ -25,38 +25,26 @@ export const router = Router();
  *            schema:
  *              type: object
  *              properties:
- *                login:
- *                  description: 인트라 아이디
- *                  type: string
- *                  example: yena
  *                content:
- *                  description: 태그 내용
+ *                  description: 슈퍼 태그 내용
  *                  type: string
  *                  example: "수정할_내용_적기"
  *      responses:
  *        '200':
- *          description: 수정된 태그를 반환합니다.
+ *          description: 수정된 슈퍼 태그를 반환합니다.
  *          content:
  *            application/json:
  *              schema:
  *                type: object
  *                properties:
  *                  id:
- *                    description: 수정된 태그의 id
+ *                    description: 수정된 슈퍼 태그의 id
  *                    type: integer
  *                    example: 1
- *                  login:
- *                    description: 인트라 아이디
- *                    type: string
- *                    example: yena
  *                  content:
- *                    description: 태그 내용
+ *                    description: 수정된 슈퍼 태그 내용
  *                    type: string
  *                    example: "수정된_태그"
- *                  count:
- *                    description: 태그 개수
- *                    type: integer
- *                    example: 1
  *        '900':
  *          description: 태그의 양식이 올바르지 않습니다.
  *          content:
@@ -100,7 +88,7 @@ export const router = Router();
  *                    description: 에러코드
  *                    example: 1
  */
-router.patch('/update/:id', authValidate(roleSet.all) /* ,update */);
+router.patch('/tags/{superTagId}', authValidate(roleSet.librarian) /* ,update */);
 
 /**
  * @openapi
@@ -116,38 +104,34 @@ router.patch('/update/:id', authValidate(roleSet.all) /* ,update */);
  *            schema:
  *              type: object
  *              properties:
- *                sourceId:
- *                  description: 병합될 태그의 id 값
- *                  type: integer
+ *                subTagIds:
+ *                  description: 병합될 서브 태그의 id 리스트
+ *                  type: list
  *                  required: true
- *                  example: 1
- *                targetId:
- *                  description: 병합할 태그의 id 값
+ *                  example: [1, 2, 3, 5, 10]
+ *                superTagId:
+ *                  description: 슈퍼 태그의 id
  *                  type: integer
  *                  required: true
  *                  example: 2
  *      responses:
  *        '200':
- *          description: 병합 후의 태그를 반환합니다.
+ *          description: 병합 후의 슈퍼 태그를 반환합니다.
  *          content:
  *            application/json:
  *              schema:
  *                type: object
  *                properties:
  *                  id:
- *                    description: 병합된 태그의 id
+ *                    description: 슈퍼 태그의 id
  *                    type: integer
  *                    example: 3
- *                  login:
- *                    description: 인트라 아이디 리스트
- *                    type: list
- *                    example: ['yena', 'chanheki', 'jang-cho']
  *                  content:
  *                    description: 태그 내용
  *                    type: string
  *                    example: "병합된_태그"
  *                  count:
- *                    description: 태그 개수
+ *                    description: 해당 슈퍼 태그에 속한 서브 태그의 개수
  *                    type: integer
  *                    example: 3
  *        '901':

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -197,4 +197,4 @@ router.patch('/tags', authValidate(roleSet.all) /* ,update */);
  *                    description: 에러코드
  *                    example: 1
  */
-router.patch('/update/:id', authValidate(roleSet.librarian) /* ,merge */);
+router.patch('/tags/merge', authValidate(roleSet.librarian) /* ,merge */);

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -1,0 +1,253 @@
+import { Router } from 'express';
+import authValidate from '../auth/auth.validate';
+import { roleSet } from '../auth/auth.type';
+
+export const path = '/tags';
+export const router = Router();
+
+router
+  /**
+   * @openapi
+   * /api/tags:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 서브/디폴트 태그 정보를 검색한다.
+   *      description: 서브/디폴트 태그 정보를 검색한다. 이는 태그 관리 페이지에서 사용한다.
+   *      parameters:
+   *        - name: page
+   *          in: query
+   *          description: 검색 결과의 페이지.
+   *          schema:
+   *            type: integer
+   *            default: 1
+   *            example: 1
+   *        - name: limit
+   *          in: query
+   *          description: 검색 결과 한 페이지당 보여줄 결과물의 개수.
+   *          schema:
+   *            type: integer
+   *            default: 10
+   *            example: 10
+   *        - name: visibility
+   *          in: query
+   *          description: 공개 및 비공개 여부로, public 이면 공개, private 이면 비공개 서브 태그만 가져온다.
+   *          required: true
+   *          schema:
+   *            type: string
+   *            default: public
+   *            example: public
+   *            enum: [public, private]
+   *        - name: title
+   *          in: query
+   *          description: 검색할 도서의 제목. 검색 결과는 도서 제목에 해당하는 태그들을 반환한다.
+   *          schema:
+   *            type: string
+   *            example: 깐깐하게 배우는 C
+   *            nullable: true
+   *      responses:
+   *        '200':
+   *          description: 슈퍼/서브/디폴트 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 태그 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        bookInfoId:
+   *                          description: 태그가 등록된 도서의 infoId
+   *                          type: integer
+   *                          example: 1
+   *                        title:
+   *                          description: 태그가 등록된 도서의 제목
+   *                          type: string
+   *                          example: 깐깐하게 배우는 C
+   *                        id:
+   *                          description: 태그 고유 id
+   *                          type: integer
+   *                          example: 1
+   *                        createdAt:
+   *                          description: 태그가 등록된 시간
+   *                          type: string
+   *                          example: 2023-04-12
+   *                        nickname:
+   *                          description: 태그를 작성한 카뎃의 닉네임
+   *                          type: string
+   *                          example: yena
+   *                        content:
+   *                          description: 슈퍼 태그의 내용
+   *                          type: string
+   *                          example: 1서클_추천_책
+   *                  meta:
+   *                    description: 모든 태그 수와 관련된 정보
+   *                    type: object
+   *                    properties:
+   *                      totalItems:
+   *                        description: 전체 검색 결과 수
+   *                        type: integer
+   *                        example: 1
+   *                      itemCount:
+   *                        description: 현재 페이지 검색 결과 수
+   *                        type: integer
+   *                        example: 1
+   *                      itemsPerPage:
+   *                        description: 페이지 당 검색 결과 수
+   *                        type: integer
+   *                        example: 10
+   *                      totalPages:
+   *                        description: 전체 결과 페이지 수
+   *                        type: integer
+   *                        example: 1
+   *                      currentPage:
+   *                        description: 현재 페이지
+   *                        type: integer
+   *                        example: 1
+   *          '400':
+   *            description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *          '401':
+   *            description: 태그 기록을 조회할 권한이 없는 사용자
+   *          '500':
+   *            description: db 에러
+   */
+  .get('/tags', authValidate(roleSet.all) /* , searchSubTag */);
+
+router
+  /**
+   * @openapi
+   * /api/tags/{superTagId}/sub:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 슈퍼 태그에 속한 서브 태그 목록을 가져온다.
+   *      description: superTagId에 해당하는 슈퍼 태그에 속한 서브 태그 목록을 가져온다. 태그 병합 페이지에서 슈퍼 태그의
+   *                   서브 태그를 가져올 때 사용한다.
+   *      parameters:
+   *        - in: path
+   *          name: superTagId
+   *          description: 서브 태그를 조회할 슈퍼 태그의 id
+   *          required: true
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그에 속한 서브 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 슈퍼 태그에 속한 서브 태그 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        id:
+   *                          description: 서브 태그 고유 id
+   *                          type: integer
+   *                        content:
+   *                          description: 서브 태그의 내용
+   *                          type: string
+   *                        login:
+   *                          description: 서브 태그를 작성한 카뎃의 인트라 id
+   *                          type: string
+   *                    example:
+   *                    - id: 0
+   *                      content: 도커_쿠버네티스
+   *                      login: yena
+   *                    - id: 42
+   *                      content: 도커
+   *                      login: yena
+   *                    - id: 50
+   *                      content: 도커
+   *                      login: jang-cho
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/tags/{superTagId}/sub', authValidate(roleSet.librarian) /* , searchSubTag */);
+
+router
+  /**
+   * @openapi
+   * /api/tags/{bookInfoId}:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 도서에 등록된 슈퍼 태그, 디폴트 태그 목록을 가져온다.
+   *      description: 슈퍼 태그(노출되는 태그), 디폴트 태그(노출되지 않고 분류되지 않은 태그)를 가져온다.
+   *                   이는 도서 상세 페이지 및 태그 병합 페이지에서 사용된다.
+   *      parameters:
+   *        - in: path
+   *          name: bookInfoId
+   *          description: 태그를 조회할 도서의 infoId
+   *          required: true
+   *          schema:
+   *            type: integer
+   *            example: 1
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그, 디폴트 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 슈퍼 태그, 디폴트 태그 목록
+   *                    type: object
+   *                    properties:
+   *                      superTags:
+   *                        description: 슈퍼 태그 목록
+   *                        type: array
+   *                        items:
+   *                          type: object
+   *                          properties:
+   *                            id:
+   *                              description: 슈퍼 태그 고유 id
+   *                              type: integer
+   *                            content:
+   *                              description: 슈퍼 태그 내용
+   *                              type: string
+   *                            count:
+   *                              description: 슈퍼 태그에 속한 서브 태그 개수
+   *                              type: integer
+   *                              default: 1
+   *                        example:
+   *                          - id: 0
+   *                            content: 1서클_추천_책
+   *                            count: 3
+   *                          - id: 42
+   *                            content: 커리어
+   *                            count: 1
+   *                      defaultTags:
+   *                        description: 디폴트 태그 목록
+   *                        type: array
+   *                        items:
+   *                          type: object
+   *                          properties:
+   *                            id:
+   *                              description: 디폴트 태그 고유 id
+   *                              type: integer
+   *                            content:
+   *                              description: 디폴트 태그 내용
+   *                              type: string
+   *                        example:
+   *                          - id: 0
+   *                            content: yena가_추천하는
+   *                          - id: 42
+   *                            content: 마법같은_파이썬
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/tags/merge', authValidate(roleSet.librarian) /* , searchSubTag */);

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -1,12 +1,131 @@
 import { Router } from 'express';
 import authValidate from '../auth/auth.validate';
 import { roleSet } from '../auth/auth.type';
+import { wrapAsyncController } from '../middlewares/wrapAsyncController';
 
 export const path = '/tags';
 export const router = Router();
 
 router
   /**
+     * @openapi
+     * /api/tags:
+     *    post:
+     *      description: 태그를 생성한다. 태그 길이는 42자 미만으로 해야한다.
+     *      tags:
+     *      - tags
+     *      requestBody:
+     *        required: true
+     *        content:
+     *          application/json:
+     *            schema:
+     *              type: object
+     *              properties:
+     *                bookInfoId:
+     *                  type: number
+     *                  nullable: false
+     *                  required: true
+     *                  example: 42
+     *                content:
+     *                  type: string
+     *                  nullable: false
+     *                  required: true
+     *                  example: "Python"
+     *      responses:
+     *         '201':
+     *            description: 태그가 DB에 정상적으로 insert됨.
+     *         '400':
+     *            description: 잘못된 요청.
+     *            content:
+     *              application/json:
+     *                schema:
+     *                  type: object
+     *                examples:
+     *                  유효하지 않은 content 길이 :
+     *                    value:
+     *                      errorCode: 801
+     *         '401':
+     *            description: 권한 없음.
+     *            content:
+     *              application/json:
+     *                schema:
+     *                  type: object
+     *                examples:
+     *                  토큰 누락 :
+     *                    value:
+     *                      errorCode: 100
+     *                  토큰 유저 존재하지 않음 :
+     *                    value :
+     *                      errorCode: 101
+     *                  토큰 만료 :
+     *                    value :
+     *                      errorCode: 108
+     *                  토큰 유효하지 않음 :
+     *                    value :
+     *                      errorCode: 109
+     */
+    .post('/', authValidate(roleSet.all), /*wrapAsyncController(createtags)*/);
+
+router
+    /**
+     * @openapi
+     * /api/tags/{tagsId}:
+     *    delete:
+     *      description: 책 태그를 삭제한다. 작성자와 사서 권한이 있는 사용자만 삭제할 수 있다.
+     *      tags:
+     *      - tags
+     *      parameters:
+     *      - name: tagsId
+     *        required: true
+     *        in: path
+     *        description: 들어온 tagsId에 해당하는 태그를 삭제한다.
+     *      responses:
+     *         '200':
+     *            description: 태그가 DB에서 정상적으로 delete됨.
+     *         '400':
+     *            content:
+     *              application/json:
+     *                schema:
+     *                  type: object
+     *                examples:
+     *                 적절하지 않는 tagsId 값:
+     *                   value:
+     *                     errorCode: 800
+     *         '401':
+     *            description: 권한 없음.
+     *            content:
+     *              application/json:
+     *                schema:
+     *                  type: object
+     *                examples:
+     *                  토큰 누락 :
+     *                    value:
+     *                      errorCode: 100
+     *                  토큰 유저 존재하지 않음 :
+     *                    value :
+     *                      errorCode: 101
+     *                  토큰 만료 :
+     *                    value :
+     *                      errorCode: 108
+     *                  토큰 유효하지 않음 :
+     *                    value :
+     *                      errorCode: 109
+     *                  토큰 userId와 태그 userID 불일치 && 사서 권한 없음 :
+     *                    value :
+     *                      errorCode: 801
+     *         '404':
+     *            description: 존재하지 않는 tagsId.
+     *            content:
+     *              application/json:
+     *                schema:
+     *                  type: object
+     *                examples:
+     *                  존재하지 않는 tagsId :
+     *                    value:
+     *                      errorCode: 804
+     */
+    .delete('/:reviewsId', authValidate(roleSet.all), /*wrapAsyncController(deleteReviews)*/);
+
    * @openapi
    * /api/tags:
    *    get:

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -7,31 +7,41 @@ export const router = Router();
 
 /**
  * @openapi
- * /api/tags/{superTagId}:
+ * /api/tags/:
  *    patch:
- *      description: 슈퍼 태그를 수정한다.
+ *      description: 태그를 수정한다.
  *      tags:
  *        - tags
  *      parameters:
- *        - in: path
- *          name: superTagId
- *          description: 변경할 슈퍼 태그의 id 값
- *          required: true
- *          schema:
- *            type: integer
  *      requestBody:
  *        content:
  *          application/json:
  *            schema:
  *              type: object
  *              properties:
+ *                id:
+ *                  description: 수정할 태그의 id
+ *                  type: integer
+ *                  example: 1
+ *                  required: true
+ *                type:
+ *                  description: 수정할 태그의 타입
+ *                  type: string
+ *                  enum: [super, sub, default]
+ *                  example: super
+ *                  required: true
  *                content:
  *                  description: 슈퍼 태그 내용
  *                  type: string
  *                  example: "수정할_내용_적기"
+ *                visible:
+ *                  description: 태그의 공개 여부
+ *                  type: string
+ *                  example: public
+ *                  enum: [public, private]
  *      responses:
  *        '200':
- *          description: 수정된 슈퍼 태그를 반환합니다.
+ *          description: 수정된 슈퍼 태그를 반환한다.
  *          content:
  *            application/json:
  *              schema:
@@ -41,10 +51,20 @@ export const router = Router();
  *                    description: 수정된 슈퍼 태그의 id
  *                    type: integer
  *                    example: 1
+ *                  type:
+ *                    description: 수정된 슈퍼 태그의 타입
+ *                    type: string
+ *                    example: "super"
+ *                    enum: [super, sub, default]
  *                  content:
  *                    description: 수정된 슈퍼 태그 내용
  *                    type: string
  *                    example: "수정된_태그"
+ *                  visible:
+ *                    description: 수정된 슈퍼 태그의 공개 여부
+ *                    type: string
+ *                    example: "public"
+ *                    enum: [public, private]
  *        '900':
  *          description: 태그의 양식이 올바르지 않습니다.
  *          content:
@@ -88,7 +108,7 @@ export const router = Router();
  *                    description: 에러코드
  *                    example: 1
  */
-router.patch('/tags/{superTagId}', authValidate(roleSet.librarian) /* ,update */);
+router.patch('/tags', authValidate(roleSet.all) /* ,update */);
 
 /**
  * @openapi

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -1,0 +1,196 @@
+import { Router } from 'express';
+import { roleSet } from '../auth/auth.type';
+import authValidate from '../auth/auth.validate';
+
+export const path = '/tags';
+export const router = Router();
+
+/**
+ * @openapi
+ * /api/tags/{id}:
+ *    patch:
+ *      description: 태그를 수정한다.
+ *      tags:
+ *        - tags
+ *      parameters:
+ *        - in: path
+ *          name: id
+ *          description: 변경할 태그의 id 값
+ *          required: true
+ *          schema:
+ *            type: integer
+ *      requestBody:
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                login:
+ *                  description: 인트라 아이디
+ *                  type: string
+ *                  example: yena
+ *                content:
+ *                  description: 태그 내용
+ *                  type: string
+ *                  example: "수정할_내용_적기"
+ *      responses:
+ *        '200':
+ *          description: 수정된 태그를 반환합니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  id:
+ *                    description: 수정된 태그의 id
+ *                    type: integer
+ *                    example: 1
+ *                  login:
+ *                    description: 인트라 아이디
+ *                    type: string
+ *                    example: yena
+ *                  content:
+ *                    description: 태그 내용
+ *                    type: string
+ *                    example: "수정된_태그"
+ *                  count:
+ *                    description: 태그 개수
+ *                    type: integer
+ *                    example: 1
+ *        '900':
+ *          description: 태그의 양식이 올바르지 않습니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  errorCode:
+ *                    type: integer
+ *                    example: 900
+ *        '901':
+ *          description: 권한이 없습니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  errorCode:
+ *                    type: integer
+ *                    example: 901
+ *        '902':
+ *          description: 이미 존재하는 태그입니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  errorCode:
+ *                    type: integer
+ *                    example: 902
+ *        '500':
+ *          description: DB Error
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                description: error decription
+ *                properties:
+ *                  errorCode:
+ *                    type: number
+ *                    description: 에러코드
+ *                    example: 1
+ */
+router.patch('/update/:id', authValidate(roleSet.all) /* ,update */);
+
+/**
+ * @openapi
+ * /api/tags/merge:
+ *    patch:
+ *      description: 태그를 병합한다.
+ *      tags:
+ *        - tags
+ *      parameters:
+ *      requestBody:
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                sourceId:
+ *                  description: 병합될 태그의 id 값
+ *                  type: integer
+ *                  required: true
+ *                  example: 1
+ *                targetId:
+ *                  description: 병합할 태그의 id 값
+ *                  type: integer
+ *                  required: true
+ *                  example: 2
+ *      responses:
+ *        '200':
+ *          description: 병합 후의 태그를 반환합니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  id:
+ *                    description: 병합된 태그의 id
+ *                    type: integer
+ *                    example: 3
+ *                  login:
+ *                    description: 인트라 아이디 리스트
+ *                    type: list
+ *                    example: ['yena', 'chanheki', 'jang-cho']
+ *                  content:
+ *                    description: 태그 내용
+ *                    type: string
+ *                    example: "병합된_태그"
+ *                  count:
+ *                    description: 태그 개수
+ *                    type: integer
+ *                    example: 3
+ *        '901':
+ *          description: 권한이 없습니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  errorCode:
+ *                    type: integer
+ *                    example: 901
+ *        '904':
+ *          description: 존재하지 않는 태그 ID 입니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  errorCode:
+ *                    type: integer
+ *                    example: 904
+ *        '910':
+ *          description: 유효하지 않은 양식의 태그 ID 입니다.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  errorCode:
+ *                    type: integer
+ *                    example: 910
+ *        '500':
+ *          description: DB Error
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                description: error decription
+ *                properties:
+ *                  errorCode:
+ *                    type: number
+ *                    description: 에러코드
+ *                    example: 1
+ */
+router.patch('/update/:id', authValidate(roleSet.librarian) /* ,merge */);


### PR DESCRIPTION
### 개요
- 태그 수정 API 추가
- 태그 병합 API 추가

### 작업 사항
- 태그 수정 API 추가
- 태그 병합 API 추가

### 변경점
- `routes/tags.routes.ts` 추가
- `routes/books.routes.ts`에 태그 수정 API 추가

### 목적
- 태그 기능 추가

### 스크린샷 (optional)
