### PR TITLE
HOTFIX: `.gitignore` 규칙 강화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.env*
+.env.*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
### 개요
- fixes #430 

### 작업 사항
다양한 종류의 `.env`파일에 대응되도록 `.gitignore` 강화

### 변경점
`.gitignore`에 패턴 추가

### 목적
`.env.local` 등 여러 종류의 `.env`파일에 대한 지원 강화