### PR TITLE
243 errorwrapper를 활용한 에러처리

### DIFF
--- a/backend/src/book-info-reviews/controller/utils/errorCheck.ts
+++ b/backend/src/book-info-reviews/controller/utils/errorCheck.ts
@@ -1,16 +1,17 @@
 import * as errorCode from '../../../utils/error/errorCode';
+import ErrorResponse from "../../../utils/error/errorResponse";
 
 export const bookInfoParseCheck = (
   bookInfoId : string,
 ) => {
   let result : number;
   if (bookInfoId.trim() === '') {
-    throw new Error(errorCode.INVALID_INPUT);
+    throw new ErrorResponse(errorCode.INVALID_INPUT, 400);
   }
   try {
     result = parseInt(bookInfoId, 10);
   } catch (error : any) {
-    throw new Error(errorCode.INVALID_INPUT);
+    throw new ErrorResponse(errorCode.INVALID_INPUT, 400);
   }
   return result;
 };

--- a/backend/src/middlewares/wrapAsyncController.ts
+++ b/backend/src/middlewares/wrapAsyncController.ts
@@ -1,26 +1,14 @@
 /* eslint-disable import/prefer-default-export */
-import * as status from 'http-status';
+import {
+  NextFunction,
+  Request, Response,
+} from 'express';
 import ErrorResponse from '../utils/error/errorResponse';
 import * as errorCode from '../utils/error/errorCode';
 
-export const wrapAsyncController = (fn : any) => (req: any, res: any, next: any) => {
-  fn(req, res, next).catch((error : any) => {
-    if (error.message === errorCode.INVALID_INPUT_REVIEWS_CONTENT) {
-      next(new ErrorResponse(errorCode.INVALID_INPUT_REVIEWS_CONTENT, 400));
-    } else if (error.message === errorCode.INVALID_INPUT) {
-      next(new ErrorResponse(errorCode.INVALID_INPUT, 400));
-    } else if (error.message === errorCode.INVALID_INPUT_REVIEWS_ID) {
-      next(new ErrorResponse(errorCode.INVALID_INPUT_REVIEWS_ID, 400, next));
-    } else if (error.message === errorCode.DISABLED_REVIEWS) {
-      next(new ErrorResponse(errorCode.DISABLED_REVIEWS, 401, next));
-    } else if (error.message === errorCode.UNAUTHORIZED_REVIEWS) {
-      next(new ErrorResponse(errorCode.UNAUTHORIZED_REVIEWS, 401, next));
-    } else if (error.message === errorCode.NOT_FOUND_REVIEWS) {
-      next(new ErrorResponse(errorCode.NOT_FOUND_REVIEWS, 404, next));
-    } else if (error.message === errorCode.INVALID_INPUT_REVIEWS) {
-      next(new ErrorResponse(errorCode.INVALID_INPUT_REVIEWS, status.BAD_REQUEST));
-    } else {
-      next(new ErrorResponse(errorCode.UNKNOWN_ERROR, 500));
-    }
-  });
+const wrapAsyncController = (fn: Function) => (req: Request, res: Response, next: NextFunction) => {
+  fn(req, res, next).catch((error: ErrorResponse) => next(error));
+  fn(req, res, next).catch(() => next(new ErrorResponse(errorCode.UNKNOWN_ERROR, 500)));
 };
+
+export default wrapAsyncController;

--- a/backend/src/reviews/controller/utils/errorCheck.ts
+++ b/backend/src/reviews/controller/utils/errorCheck.ts
@@ -1,5 +1,6 @@
 import * as errorCode from '../../../utils/error/errorCode';
 import ReviewsService from '../../service/reviews.service';
+import ErrorResponse from "../../../utils/error/errorResponse";
 
 const reviewsService = new ReviewsService();
 
@@ -8,7 +9,7 @@ export const contentParseCheck = (
 ) => {
   const result = content.trim();
   if (result === '' || result.length < 10 || result.length > 420) {
-    throw new Error(errorCode.INVALID_INPUT_REVIEWS_CONTENT);
+    throw new ErrorResponse(errorCode.INVALID_INPUT_REVIEWS_CONTENT, 400);
   }
   return result;
 };
@@ -17,12 +18,12 @@ export const reviewsIdParseCheck = (
   reviewsId : string,
 ) => {
   if (reviewsId.trim() === '') {
-    throw new Error(errorCode.INVALID_INPUT_REVIEWS_ID);
+    throw new ErrorResponse(errorCode.INVALID_INPUT_REVIEWS_ID, 400);
   }
   try {
     return parseInt(reviewsId, 10);
   } catch (error : any) {
-    throw new Error(errorCode.INVALID_INPUT_REVIEWS);
+    throw new ErrorResponse(errorCode.INVALID_INPUT_REVIEWS, 400);
   }
 };
 
@@ -33,7 +34,7 @@ export const reviewsIdExistCheck = async (
   try {
     result = await reviewsService.getReviewsUserId(reviewsId);
   } catch (error : any) {
-    throw new Error(errorCode.NOT_FOUND_REVIEWS);
+    throw new ErrorResponse(errorCode.NOT_FOUND_REVIEWS, 404);
   }
   return result;
 };
@@ -43,6 +44,6 @@ export const idAndTokenIdSameCheck = (
   tokenId : number,
 ) => {
   if (id !== tokenId) {
-    throw new Error(errorCode.UNAUTHORIZED_REVIEWS);
+    throw new ErrorResponse(errorCode.UNAUTHORIZED_REVIEWS, 401);
   }
 };

--- a/backend/src/reviews/repository/reviews.repository.ts
+++ b/backend/src/reviews/repository/reviews.repository.ts
@@ -4,6 +4,7 @@ import Reviews from '../../entity/entities/Reviews';
 import * as errorCode from '../../utils/error/errorCode';
 import BookInfo from '../../entity/entities/BookInfo';
 import User from '../../entity/entities/User';
+import ErrorResponse from "../../utils/error/errorResponse";
 
 export default class ReviewsRepository extends Repository<Reviews> {
   private readonly bookInfoRepo: Repository<BookInfo>;
@@ -23,7 +24,7 @@ export default class ReviewsRepository extends Repository<Reviews> {
       where: { id: bookInfoId },
     });
     if (bookInfoCount === 0) {
-      throw new Error(errorCode.INVALID_INPUT_REVIEWS);
+      throw new ErrorResponse(errorCode.INVALID_INPUT_REVIEWS, 400);
     }
   }
 

--- a/backend/src/reviews/service/utils/errorCheck.ts
+++ b/backend/src/reviews/service/utils/errorCheck.ts
@@ -1,5 +1,6 @@
 import * as errorCode from '../../../utils/error/errorCode';
 import ReviewsRepository from '../../repository/reviews.repository';
+import ErrorResponse from "../../../utils/error/errorResponse";
 
 const reviewsRepository = new ReviewsRepository();
 
@@ -12,10 +13,10 @@ export const updatePossibleCheck = async (
     result = await reviewsRepository.getReviews(reviewsId);
     resultId = result[0].userId;
   } catch (error : any) {
-    throw new Error(errorCode.NOT_FOUND_REVIEWS);
+    throw new ErrorResponse(errorCode.NOT_FOUND_REVIEWS, 404);
   }
   if (result[0].disabled === 1) {
-    throw new Error(errorCode.DISABLED_REVIEWS);
+    throw new ErrorResponse(errorCode.DISABLED_REVIEWS, 401);
   }
   return resultId;
 };
@@ -25,6 +26,6 @@ export const idAndTokenIdSameCheck = (
   tokenId : number,
 ) => {
   if (id !== tokenId) {
-    throw new Error(errorCode.UNAUTHORIZED_REVIEWS);
+    throw new ErrorResponse(errorCode.UNAUTHORIZED_REVIEWS, 401);
   }
 };

--- a/backend/src/routes/bookInfoReviews.routes.ts
+++ b/backend/src/routes/bookInfoReviews.routes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import {
   getBookInfoReviewsPage,
 } from '../book-info-reviews/controller/bookInfoReviews.controller';
-import { wrapAsyncController } from '../middlewares/wrapAsyncController';
+import wrapAsyncController from '../middlewares/wrapAsyncController';
 
 export const path = '/book-info';
 export const router = Router();

--- a/backend/src/routes/reviews.routes.ts
+++ b/backend/src/routes/reviews.routes.ts
@@ -4,7 +4,7 @@ import {
 } from '../reviews/controller/reviews.controller';
 import authValidate from '../auth/auth.validate';
 import { roleSet } from '../auth/auth.type';
-import { wrapAsyncController } from '../middlewares/wrapAsyncController';
+import wrapAsyncController from '../middlewares/wrapAsyncController';
 
 export const path = '/reviews';
 export const router = Router();


### PR DESCRIPTION
### 개요
- 비즈니스 레이어에서 던지는 예외를 일괄적으로 처리하는 미들웨어를 추가합니다.

### 작업 사항
- wrapAsyncController 기능 변경
- Reviews 레이어에서 예외를 Error -> ErrorResponse로 던지도록 변경

### 변경점
- 기존 wrapAsyncController의 불필요한 조건문을 제거
- ErrorResponse, Error에 따른 분기만 처리하는 것으로 변경

### 목적
- 라우터에서 호출하는 함수를 감싸는 형태로 사용합니다.
- 비즈니스 레이어에서 던지는 ErrorResponse는 예상한 오류라고 판단하고 인자 그대로 NextFunction으로 반환합니다.
- 비즈니스 레이어에서 던지는 Error는 예상하지 못한 오류라고 판단하고 Unknown 에러를 반환합니다.
