### PR TITLE
build: 테스트 DB 실행용 도커파일

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:16
+FROM node:19
 
-COPY . .
-RUN yarn
+WORKDIR /app
 
-ENTRYPOINT [ "sh", "start.sh"]
+COPY . /app
+ENTRYPOINT [ "yarn", "run", "container" ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:19
 
 WORKDIR /app
-
 COPY . /app
+
+RUN yarn install
+
 ENTRYPOINT [ "yarn", "run", "container" ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "build": "npx tsc -p .",
     "dev": "nodemon --watch \"src/**/*.ts\" --exec \"ts-node\" src/server.ts",
     "prod": "npx tsc -p . && yarn start",
+    "container": "tsx src/server.ts",
     "test": "jest"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@types/winston": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
+    "tsx": "^3.12.6",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,6 @@
     "@types/winston": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "tsx": "^3.12.6",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.4",
@@ -42,6 +41,7 @@
     "prettier": "^2.5.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
+    "tsx": "^3.12.6",
     "typescript": "^4.5.5"
   },
   "dependencies": {
@@ -70,6 +70,7 @@
     "typeorm": "^0.3.11",
     "typeorm-model-generator": "^0.4.6",
     "winston": "^3.6.0",
-    "winston-daily-rotate-file": "^4.6.1"
+    "winston-daily-rotate-file": "^4.6.1",
+    "zod": "^3.21.4"
   }
 }

--- a/backend/src/app-data-source.ts
+++ b/backend/src/app-data-source.ts
@@ -11,7 +11,7 @@ let database;
 
 switch (process.env.MODE) {
   case 'local':
-    hostName = 'localhost';
+    hostName = process.env.MYSQL_HOSTNAME ?? 'local';
     username = process.env.MYSQL_USER;
     password = process.env.MYSQL_PASSWORD;
     database = process.env.MYSQL_DATABASE;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,10 +38,6 @@ jipDataSource.initialize().then(
     logger.info('typeORM INIT SUCCESS');
     logger.info(process.env.MODE);
   },
-).catch(
-  (e) => {
-    logger.error(`typeORM INIT FAILED : ${e.message}`);
-  },
 );
 
 // Swagger 연결

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -9,7 +9,7 @@ let database;
 
 switch (process.env.MODE) {
   case 'local':
-    hostName = 'local';
+    hostName = process.env.MYSQL_HOSTNAME ?? 'local';
     username = process.env.MYSQL_USER;
     password = process.env.MYSQL_PASSWORD;
     database = process.env.MYSQL_DATABASE;
@@ -24,7 +24,7 @@ switch (process.env.MODE) {
     hostName = 'database';
     username = process.env.MYSQL_USER;
     password = process.env.MYSQL_PASSWORD;
-    database = process.env.MYSQL_DATABASE; 
+    database = process.env.MYSQL_DATABASE;
     break;
   default:
     hostName = 'database';

--- a/backend/src/entity/entities/Book.ts
+++ b/backend/src/entity/entities/Book.ts
@@ -28,7 +28,7 @@ class Book {
   })
   createdAt?: Date;
 
-  @Column()
+  @Column('int')
   infoId: number;
 
   @Column('datetime', {

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,0 +1,62 @@
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+const localEnv = z
+  .object({
+    MYSQL_HOSTNAME: z.string().default('local'),
+    MYSQL_USER: z.string(),
+    MYSQL_PASSWORD: z.string(),
+    MYSQL_DATABASE: z.string(),
+  })
+  .transform(
+    ({ MYSQL_HOSTNAME, MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE }) => ({
+      host: MYSQL_HOSTNAME,
+      username: MYSQL_USER,
+      password: MYSQL_PASSWORD,
+      dbName: MYSQL_DATABASE,
+    }),
+  );
+
+const rdsEnv = z
+  .object({
+    RDS_HOSTNAME: z.string(),
+    RDS_USERNAME: z.string(),
+    RDS_PASSWORD: z.string(),
+    RDS_DB_NAME: z.string(),
+  })
+  .transform(({ RDS_HOSTNAME, RDS_USERNAME, RDS_PASSWORD, RDS_DB_NAME }) => ({
+    host: RDS_HOSTNAME,
+    username: RDS_USERNAME,
+    password: RDS_PASSWORD,
+    dbName: RDS_DB_NAME,
+  }));
+
+const dbEnvSchema = (() => {
+  switch (process.env.MODE) {
+    case 'local':
+      return localEnv;
+    case 'RDS':
+      return rdsEnv;
+    case 'prod':
+      return localEnv;
+    default:
+      throw new Error('MODE is not defined');
+  }
+})();
+
+export const { host, username, password, dbName } = dbEnvSchema.parse(
+  process.env,
+);
+
+const envSchema = z.object({
+  CLIENT_ID: z.string(),
+  CLIENT_SECRET: z.string(),
+  REDIRECT_URL: z.string().default('https://server.42library.kr'),
+  CLIENT_URL: z.string().default('https://42library.kr'),
+  JWT_SECRET: z.string(),
+  MODE: z.union([z.literal('local'), z.literal('RDS'), z.literal('prod')]),
+});
+
+export const env = envSchema.parse(process.env);

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -1,0 +1,31 @@
+services:
+  nginx:
+    image: nginx:stable-alpine
+    container_name: nginx
+    volumes: [./nginx/conf.d:/etc/nginx/conf.d]
+    ports: [80:80]
+    restart: always
+
+  database:
+    platform: linux/x86_64
+    container_name: database
+    image: mysql:8.0
+    environment: [TZ=Asia/Seoul]
+    env_file: .env
+    ports: [3306:3306]
+    volumes: [./mock:/docker-entrypoint-initdb.d:ro]
+    restart: always
+
+  backend:
+    container_name: backend
+    depends_on: [database]
+    build:
+      context: ./backend
+    restart: always
+    volumes:
+      - ./backend/:/app 
+    ports: [3000:3000]
+    env_file: .env
+
+volumes:
+  db_data:

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -23,9 +23,11 @@ services:
       context: ./backend
     restart: always
     volumes:
-      - ./backend/:/app 
+      - ./backend/:/app
     ports: [3000:3000]
-    env_file: .env
+    env_file: 
+      - .env
+      - .env.test
 
 volumes:
   db_data:


### PR DESCRIPTION
### 개요
![image](https://user-images.githubusercontent.com/54838975/231421123-7c451d43-8c51-4c6e-92ac-fa8768ca7d17.png)

테스트 DB, 서버, nginx를 도커파일 하나로 실행할 수 있는 compose.test.yaml을 추가했습니다.

```
docker compose  -f compose.test.yml up
```
로 실행합니다.

### 변경점

- [zod](zod.dev/) 라이브러리를 의존성에 추가했습니다. zod는 파싱 라이브러리로, 원시값에서 복잡한 객체까지 쉽게 파싱할 수 있고, 기본값과 후처리 기능도 제공합니다.


### 목적

#### zod
https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/

#### 테스트 DB
https://dominikbraun.io/blog/you-probably-shouldnt-mock-the-database/

데이터베이스를 모킹하는 것보다는 복사본을 사용해 직접 테스트하는 것이 좋다는 내용의 블로그 글이 있었고, 이에 동의하여 해당 PR을 열게 되었습니다.

- https://www.tonic.ai/blog/using-docker-to-manage-your-test-database
- https://medium.com/@ayeshajayasankha/testing-your-databases-on-docker-6f7f2e66bbee
