### PR TITLE
fix: 전체 대출반납 기록 조회 시 정렬 순서가 최신 순이 아님

### DIFF
--- a/backend/src/entity/entities/VHistories.ts
+++ b/backend/src/entity/entities/VHistories.ts
@@ -17,6 +17,7 @@ import { DataSource, ViewColumn, ViewEntity } from 'typeorm';
     .addSelect('bi.image', 'image')
     .addSelect('DATE_FORMAT(l.createdAt, "%Y-%m-%d")', 'createdAt')
     .addSelect('DATE_FORMAT(l.returnedAt, "%Y-%m-%d")', 'returnedAt')
+    .addSelect('DATE_FORMAT(l.updatedAt, "%Y-%m-%d")', 'updatedAt')
     .addSelect("DATE_FORMAT(DATE_ADD(l.createdAt, interval 14 day), '%Y-%m-%d')", 'dueDate')
     .addSelect('(SELECT nickname FROM user WHERE user.id = lendingLibrarianId)', 'lendingLibrarianNickName')
     .addSelect('(SELECT nickname FROM user WHERE user.id = returningLibrarianId)', 'returningLibrarianNickname')
@@ -58,6 +59,9 @@ export default class VHistories {
 
   @ViewColumn()
   returnedAt: Date;
+
+  @ViewColumn()
+  updatedAt: Date;
 
   @ViewColumn()
   dueDate: Date;

--- a/backend/src/histories/histories.repository.ts
+++ b/backend/src/histories/histories.repository.ts
@@ -16,8 +16,7 @@ class HistoriesRepository extends Repository<VHistories> {
       take: limit,
       skip: page * limit,
       order: {
-        createdAt: 'DESC',
-        login: 'DESC',
+        updatedAt: 'DESC',
       },
     });
     return [histories, count];

--- a/backend/src/lendings/lendings.repository.ts
+++ b/backend/src/lendings/lendings.repository.ts
@@ -169,6 +169,7 @@ class LendingRepository extends Repository<Lending> {
       returningLibrarianId,
       returningCondition,
       returnedAt: (new Date()),
+      updatedAt: (new Date()),
     };
     await this.update(lendingId, updateObject);
   }


### PR DESCRIPTION
### 개요
- 전체 대출반납 기록 조회 시, 정렬 순서가 최신 순이 아니라 `createdAt`, `login`의 내림차순임
- 따라서 대출, 반납 등의 수정이 일어났을 때를 기준으로 하여 내림차순으로 정렬함
- 반납 시, `lending.updatedAt`이 갱신되지 않는 점 수정

### 작업 사항 및 변경점
- 함수 `getHistoriesItems` 정렬 조건을 `updatedAt: 'DESC'`로 변경
- 함수 `updateLending` 호출 시, `updatedAt` 값도 같이 업데이트

### 목적
대출/반납 기록 조회 시, 최신 순으로 정렬하기 위함
