### PR TITLE
fix: "undefined" 검색 시 전체 도서 목록 반환을 방지

### DIFF
--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -90,7 +90,7 @@ export const searchBookInfo = async (
   next: NextFunction,
 ) => {
   // URI에 있는 파라미터/쿼리 변수에 저장
-  const query = String(req.query.query) !== 'undefined' ? String(req.query.query) : '';
+  const query = req.query?.query ?? '';
   const {
     page, limit, sort, category,
   } = req.query;


### PR DESCRIPTION
### 개요
![image](https://user-images.githubusercontent.com/54838975/233783168-5c9acdaa-a907-4a25-a6db-616852dfcf72.png)

### 작업 사항

[옵셔널 체이닝](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/Optional_chaining)과 [널 병합 연산자](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing)를 써서 query값이 undefined일시만 `''`을 사용하도록 했습니다.

### 목적
- fixes #443 
