### PR TITLE
태그 기능 조회 추가 작업

### DIFF
--- a/backend/src/entity/entities/VTagsSubDefault.ts
+++ b/backend/src/entity/entities/VTagsSubDefault.ts
@@ -15,6 +15,7 @@ import User from './User';
     .addSelect('sp.id', 'superTagId')
     .addSelect('sp.content', 'superContent')
     .addSelect('sb.isPublic', 'isPublic')
+    .addSelect('sb.isDeleted', 'isDeleted')
     .from(SuperTag, 'sp')
     .innerJoin(SubTag, 'sb', 'sb.superTagId = sp.id')
     .innerJoin(BookInfo, 'bi', 'bi.id = sp.bookInfoId')
@@ -47,6 +48,9 @@ export class VTagsSubDefault {
 
   @ViewColumn()
   isPublic: boolean;
+
+  @ViewColumn()
+  isDeleted: boolean;
 }
 
 export default VTagsSubDefault;

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -705,19 +705,25 @@ router
    *                      count:
    *                        description: 슈퍼 태그에 속한 서브 태그 개수. 슈퍼 태그는 기본값이 1이며, 0이면 디폴트 태그를 의미한다.
    *                        type: integer
+   *                      login:
+   *                        description: 태그를 작성한 카뎃의 인트라 id. 슈퍼 태그는 기본값이 null이며, 디폴트 태그만 작성자 값이 있다.
    *                    example:
    *                    - id: 0
    *                      content: 1서클_추천_책
    *                      count: 3
+   *                      login:
    *                    - id: 42
    *                      content: 커리어
    *                      count: 1
+   *                      login:
    *                    - id: 0
    *                      content: yena가_추천하는
    *                      count: 0
+   *                      login: yena
    *                    - id: 42
    *                      content: 마법같은_파이썬
    *                      count: 0
+   *                      login: yena
    *        '400':
    *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
    *        '401':
@@ -725,4 +731,4 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/:bookInfoId', authValidate(roleSet.librarian), searchSuperDefaultTags);
+  .get('/:bookInfoId', authValidate(roleSet.all), searchSuperDefaultTags);

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -93,17 +93,14 @@ export const mergeTags = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const tagsService = new TagsService();
   const { id: tokenId } = req.user as any;
-  if (await tagsService.isLibrarian(tokenId) === false) {
-    return next(new ErrorResponse(errorCode.UNAUTHORIZED_TAGS, 401));
-  }
   const superTagId = parseInt(req?.body?.superTagId, 10);
   const rawSubTagIds = req?.body?.subTagIds;
   const subTagIds: number[] = [];
   rawSubTagIds.forEach((subTagId: string) => {
     subTagIds.push(parseInt(subTagId, 10));
   });
+  const tagsService = new TagsService();
   if (await tagsService.isDefaultTag(superTagId) === true) {
     return next(new ErrorResponse(errorCode.DEFAULT_TAG_ID, 400));
   }

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -93,14 +93,17 @@ export const mergeTags = async (
   res: Response,
   next: NextFunction,
 ) => {
+  const tagsService = new TagsService();
   const { id: tokenId } = req.user as any;
+  if (await tagsService.isLibrarian(tokenId) === false) {
+    return next(new ErrorResponse(errorCode.UNAUTHORIZED_TAGS, 401));
+  }
   const superTagId = parseInt(req?.body?.superTagId, 10);
   const rawSubTagIds = req?.body?.subTagIds;
   const subTagIds: number[] = [];
   rawSubTagIds.forEach((subTagId: string) => {
     subTagIds.push(parseInt(subTagId, 10));
   });
-  const tagsService = new TagsService();
   if (await tagsService.isDefaultTag(superTagId) === true) {
     return next(new ErrorResponse(errorCode.DEFAULT_TAG_ID, 400));
   }

--- a/backend/src/tags/tags.repository.ts
+++ b/backend/src/tags/tags.repository.ts
@@ -35,7 +35,7 @@ export class SubTagRepository extends Repository<SubTag> {
     };
     await this.insert(insertObject);
   }
-  
+
   async deleteSubTag(subTagsId: number, deleteUser: number): Promise<void> {
     await this.update(subTagsId, { isDeleted: 1, updateUserId: deleteUser });
   }
@@ -84,6 +84,9 @@ export class SubTagRepository extends Repository<SubTag> {
 
 export class SuperTagRepository extends Repository<SuperTag> {
   private readonly vSubDefaultRepo: Repository<VTagsSubDefault>;
+
+  private readonly userRepo: Repository<User>;
+
   private readonly entityManager;
 
   constructor(transactionQueryRunner?: QueryRunner) {
@@ -93,6 +96,10 @@ export class SuperTagRepository extends Repository<SuperTag> {
     this.entityManager = entityManager;
     this.vSubDefaultRepo = new Repository<VTagsSubDefault>(
       VTagsSubDefault,
+      this.entityManager,
+    );
+    this.userRepo = new Repository<User>(
+      User,
       this.entityManager,
     );
   }
@@ -134,11 +141,11 @@ export class SuperTagRepository extends Repository<SuperTag> {
     const insertResult = await this.entityManager.insert(SuperTag, insertObject);
     return insertResult.identifiers[0].id;
   }
-  
+
   async deleteSuperTag(superTagsId: number, deleteUser: number): Promise<void> {
     await this.update(superTagsId, { isDeleted: 1, updateUserId: deleteUser });
   }
-  
+
   async getSubAndSuperTags(page: number, limit: number, conditions: Object)
     : Promise<[subDefaultTag[], number]> {
     const [items, count] = await this.vSubDefaultRepo.findAndCount({
@@ -193,5 +200,14 @@ export class SuperTagRepository extends Repository<SuperTag> {
       { id: superTagId },
       { content, updateUserId, updatedAt: new Date() },
     );
+  }
+
+  async getRole(userId: number): Promise<number> {
+    const user: User | null = await this.userRepo.findOne({
+      select: ['role'],
+      where: { id: userId },
+    });
+    if (!user) { return -1; }
+    return user.role;
   }
 }

--- a/backend/src/tags/tags.repository.ts
+++ b/backend/src/tags/tags.repository.ts
@@ -170,18 +170,13 @@ export class SuperTagRepository extends Repository<SuperTag> {
   async getSuperTagsWithSubCount(bookInfoId: number)
     : Promise<superDefaultTag[]> {
     const superTags = await this.createQueryBuilder('sp')
-      .select('id', 'id')
-      .addSelect('content', 'content')
-      .loadRelationCountAndMap(
-        'sp.subTagCount',
-        'sp.subTags',
-        'count',
-        (qb) => qb.where(
-          'sp.bookInfoId = :bookInfoId',
-          { bookInfoId },
-        ),
-      )
-      .where('sp.bookInfoId = :bookInfoId', { bookInfoId })
+      .select('sp.id', 'id')
+      .addSelect('sp.content', 'content')
+      .addSelect((subQuery) => subQuery
+        .select('COUNT(sb.id)')
+        .from(SubTag, 'sb')
+        .where('sb.superTagId = sp.id'), 'count')
+      .where('sp.bookInfoId = :bookInfoId AND sp.content != \'default\'', { bookInfoId })
       .getRawMany();
     return superTags as superDefaultTag[];
   }

--- a/backend/src/tags/tags.repository.ts
+++ b/backend/src/tags/tags.repository.ts
@@ -116,7 +116,7 @@ export class SuperTagRepository extends Repository<SuperTag> {
     return superTags;
   }
 
-  async getDefaultTagId(bookInfoId: number)
+  async getDefaultTag(bookInfoId: number)
   : Promise<SuperTag | null> {
     const defaultTag = await this.findOne({
       select: [
@@ -175,8 +175,8 @@ export class SuperTagRepository extends Repository<SuperTag> {
       .addSelect((subQuery) => subQuery
         .select('COUNT(sb.id)')
         .from(SubTag, 'sb')
-        .where('sb.superTagId = sp.id'), 'count')
-      .where('sp.bookInfoId = :bookInfoId AND sp.content != \'default\'', { bookInfoId })
+        .where('sb.superTagId = sp.id AND sb.isDeleted IS FALSE AND sb.isPublic IS TRUE'), 'count')
+      .where('sp.bookInfoId = :bookInfoId AND sp.content != \'default\' AND sp.isDeleted IS FALSE', { bookInfoId })
       .getRawMany();
     return superTags as superDefaultTag[];
   }

--- a/backend/src/tags/tags.repository.ts
+++ b/backend/src/tags/tags.repository.ts
@@ -201,13 +201,4 @@ export class SuperTagRepository extends Repository<SuperTag> {
       { content, updateUserId, updatedAt: new Date() },
     );
   }
-
-  async getRole(userId: number): Promise<number> {
-    const user: User | null = await this.userRepo.findOne({
-      select: ['role'],
-      where: { id: userId },
-    });
-    if (!user) { return -1; }
-    return user.role;
-  }
 }

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -206,6 +206,14 @@ export class TagsService {
       await this.queryRunner.release();
     }
   }
+
+  async isLibrarian(userId: number): Promise<boolean> {
+    const role = await this.superTagRepository.getRole(userId);
+    if (role === 2) {
+      return true;
+    }
+    return false;
+  }
 }
 
 export default TagsService;

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -84,16 +84,21 @@ export class TagsService {
     let superDefaultTags: Array<superDefaultTag> = [];
     superDefaultTags = await this.superTagRepository.getSuperTagsWithSubCount(bookInfoId);
     const defaultTagId = await this.superTagRepository.getDefaultTagId(bookInfoId);
-    const defaultTags = await this.subTagRepository.getSubTags(
-      { superTagId: defaultTagId, isPublic: 1 },
-    );
-    defaultTags.forEach((defaultTag) => {
-      superDefaultTags.push({
-        id: defaultTag.id,
-        content: defaultTag.content,
-        count: 0,
+    if (defaultTagId) {
+      const defaultTags = await this.subTagRepository.getSubTags(
+        {
+          superTagId: defaultTagId,
+          isPublic: 1,
+        },
+      );
+      defaultTags.forEach((defaultTag) => {
+        superDefaultTags.push({
+          id: defaultTag.id,
+          content: defaultTag.content,
+          count: 0,
+        });
       });
-    });
+    }
     return superDefaultTags;
   }
 

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -25,7 +25,7 @@ export class TagsService {
   async createDefaultTags(userId: number, bookInfoId: number, content: string) {
     try {
       await this.queryRunner.startTransaction();
-      const defaultTag: SuperTag | null = await this.superTagRepository.getDefaultTagId(bookInfoId);
+      const defaultTag: SuperTag | null = await this.superTagRepository.getDefaultTag(bookInfoId);
       let defaultTagId;
       if (defaultTag === null) {
         defaultTagId = await this.superTagRepository.createSuperTag('default', bookInfoId, userId);
@@ -76,25 +76,30 @@ export class TagsService {
   }
 
   async searchSubTags(superTagId: number): Promise<Object> {
-    const subTags = await this.subTagRepository.getSubTags({ superTagId });
+    const subTags = await this.subTagRepository.getSubTags({
+      superTagId,
+      isDeleted: 0,
+      isPublic: 1,
+    });
     return subTags;
   }
 
   async searchSuperDefaultTags(bookInfoId: number): Promise<Object> {
     let superDefaultTags: Array<superDefaultTag> = [];
     superDefaultTags = await this.superTagRepository.getSuperTagsWithSubCount(bookInfoId);
-    const defaultTagId = await this.superTagRepository.getDefaultTagId(bookInfoId);
-    if (defaultTagId) {
+    const defaultTag = await this.superTagRepository.getDefaultTag(bookInfoId);
+    if (defaultTag) {
       const defaultTags = await this.subTagRepository.getSubTags(
         {
-          superTagId: defaultTagId,
+          superTagId: defaultTag.id,
           isPublic: 1,
+          isDeleted: 0,
         },
       );
-      defaultTags.forEach((defaultTag) => {
+      defaultTags.forEach((dt) => {
         superDefaultTags.push({
-          id: defaultTag.id,
-          content: defaultTag.content,
+          id: dt.id,
+          content: dt.content,
           count: 0,
         });
       });
@@ -103,9 +108,9 @@ export class TagsService {
   }
 
   async createSuperTags(userId: number, bookInfoId: number, content: string) {
-		try {
+    try {
       await this.queryRunner.startTransaction();
-			await this.superTagRepository.createSuperTag(content, bookInfoId, userId);
+      await this.superTagRepository.createSuperTag(content, bookInfoId, userId);
       await this.queryRunner.commitTransaction();
     } catch (e) {
       await this.queryRunner.rollbackTransaction();
@@ -175,7 +180,7 @@ export class TagsService {
   async isDefaultTag(superTagId: number): Promise<boolean> {
     const superTags: SuperTag[] = await this.superTagRepository.getSuperTags({ id: superTagId });
     const { bookInfoId } = superTags[0];
-    const defaultTag: SuperTag | null = await this.superTagRepository.getDefaultTagId(bookInfoId);
+    const defaultTag: SuperTag | null = await this.superTagRepository.getDefaultTag(bookInfoId);
     if (defaultTag === null || superTagId !== defaultTag.id) {
       return false;
     }

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -206,14 +206,6 @@ export class TagsService {
       await this.queryRunner.release();
     }
   }
-
-  async isLibrarian(userId: number): Promise<boolean> {
-    const role = await this.superTagRepository.getRole(userId);
-    if (role === 2) {
-      return true;
-    }
-    return false;
-  }
 }
 
 export default TagsService;


### PR DESCRIPTION
### 개요
- 슈퍼 태그에 속한 서브 태그의 개수가 조회되지 않음
- 조회 시, isDeleted, isPublic 고려

### 작업 사항
- `.loadRelationCountAndMap` 대신 서브쿼리 사용
- `/api/tags/{bookInfoId}` 접근 권한 모두로 변경

### 스크린샷 (optional)
