### PR TITLE
get tags 공개여부 응답값 추가

### DIFF
--- a/backend/src/DTO/tags.model.ts
+++ b/backend/src/DTO/tags.model.ts
@@ -6,7 +6,7 @@ export interface subDefaultTag {
   login: string;
   content: string;
   superContent: string;
-  visibility: string;
+  visibility: "public" | "private";
 }
 
 export interface superDefaultTag {

--- a/backend/src/DTO/tags.model.ts
+++ b/backend/src/DTO/tags.model.ts
@@ -6,6 +6,7 @@ export interface subDefaultTag {
   login: string;
   content: string;
   superContent: string;
+  visibility: string;
 }
 
 export interface superDefaultTag {

--- a/backend/src/entity/entities/VTagsSubDefault.ts
+++ b/backend/src/entity/entities/VTagsSubDefault.ts
@@ -16,6 +16,7 @@ import User from './User';
     .addSelect('sp.content', 'superContent')
     .addSelect('sb.isPublic', 'isPublic')
     .addSelect('sb.isDeleted', 'isDeleted')
+    .addSelect('CASE WHEN sb.isPublic = 1 THEN \'public\' ELSE 1 \'private\' END', 'visibility')
     .from(SuperTag, 'sp')
     .innerJoin(SubTag, 'sb', 'sb.superTagId = sp.id')
     .innerJoin(BookInfo, 'bi', 'bi.id = sp.bookInfoId')
@@ -51,6 +52,9 @@ export class VTagsSubDefault {
 
   @ViewColumn()
   isDeleted: boolean;
+
+  @ViewColumn()
+  visibility: string;
 }
 
 export default VTagsSubDefault;

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -576,6 +576,10 @@ router
    *                          description: 슈퍼 태그의 내용
    *                          type: string
    *                          example: 1서클_추천_책
+   *                        visibility:
+   *                          description: 공개 여부. 공개는 public, 비공개는 private이다.
+   *                          type: string
+   *                          example: public
    *                  meta:
    *                    description: 모든 태그 수와 관련된 정보
    *                    type: object

--- a/backend/src/tags/tags.repository.ts
+++ b/backend/src/tags/tags.repository.ts
@@ -157,6 +157,7 @@ export class SuperTagRepository extends Repository<SuperTag> {
         'login',
         'content',
         'superContent',
+        'visibility',
       ],
       where: conditions,
       order: { id: 'DESC' },

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -44,7 +44,7 @@ export class TagsService {
 
   async searchSubDefaultTags(page: number, limit: number, visibility: string, title: string)
   : Promise<Object> {
-    const conditions: any = {};
+    const conditions: any = { isDeleted: 0 };
     switch (visibility) {
       case 'public':
         conditions.isPublic = 1;
@@ -53,7 +53,6 @@ export class TagsService {
         conditions.isPublic = 0;
         break;
       default:
-        conditions.isPublic = 1;
         break;
     }
     if (title) { conditions.title = Like(`%${title}%`); }


### PR DESCRIPTION
### 개요
- /api/tags GET 공개여부 응답값 추가

### 작업 사항
- 응답에 공개를 나타내는 visibility 추가

### 변경점
- 뷰 구조 변경
- 서비스 레이어에서 삭제된 태그는 조회하지 못하게 함
- 스웨거 업데이트

### 목적
- 태그 기능 구현

### 스크린샷 (optional)
