### PR TITLE
/api/tags의 검색 조건 title에서 query로 변경

### DIFF
--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -527,9 +527,9 @@ router
    *            default:
    *            example: null
    *            enum: [null, public, private]
-   *        - name: title
+   *        - name: query
    *          in: query
-   *          description: 검색할 도서의 제목. 검색 결과는 도서 제목에 해당하는 태그들을 반환한다.
+   *          description: 태그가 달린 도서명 또는 태그의 내용으로 검색한다.
    *          schema:
    *            type: string
    *            example: 개발자의 코드

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -75,10 +75,10 @@ export const searchSubDefaultTags = async (
   const page: number = parseCheck.pageParse(parseInt(String(req?.query?.page), 10));
   const limit: number = parseCheck.limitParse(parseInt(String(req?.query?.limit), 10));
   const visibility: string = parseCheck.stringQueryParse(req?.query?.visibility);
-  const title: string = parseCheck.stringQueryParse(req?.query?.title);
+  const query: string = parseCheck.stringQueryParse(req?.query?.query);
   const tagsService = new TagsService();
   return res.status(status.OK)
-    .json(await tagsService.searchSubDefaultTags(page, limit, visibility, title));
+    .json(await tagsService.searchSubDefaultTags(page, limit, visibility, query));
 };
 
 export const searchSubTags = async (

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -42,20 +42,24 @@ export class TagsService {
     }
   }
 
-  async searchSubDefaultTags(page: number, limit: number, visibility: string, title: string)
+  async searchSubDefaultTags(page: number, limit: number, visibility: string, query: string)
   : Promise<Object> {
-    const conditions: any = { isDeleted: 0 };
-    switch (visibility) {
-      case 'public':
-        conditions.isPublic = 1;
-        break;
-      case 'private':
-        conditions.isPublic = 0;
-        break;
-      default:
-        break;
+    const conditions: Array<Object> = [];
+    const deleteAndVisibility: any = { isDeleted: 0, isPublic: null };
+
+    if (visibility === 'public') {
+      deleteAndVisibility.isPublic = 1;
+    } else if (visibility === 'private') {
+      deleteAndVisibility.isPublic = 0;
     }
-    if (title) { conditions.title = Like(`%${title}%`); }
+    if (query) {
+      conditions.push(
+        { ...deleteAndVisibility, title: Like(`%${query}%`) },
+        { ...deleteAndVisibility, content: Like(`%${query}%`) },
+      );
+    } else {
+      conditions.push(deleteAndVisibility);
+    }
     const [items, count] = await this.superTagRepository.getSubAndSuperTags(
       page,
       limit,


### PR DESCRIPTION
### 개요
도서 상세 페이지, 병합 용의 태그를 조회할 때 태그 내용으로도 조회 가능하게 함

### 작업 사항
- 스웨거 parameter title에서 query로 변경
- tags.service.ts에 find where 옵션 구성 변경