### PR TITLE
태그를 병합할 때, 서브 태그를 디폴트 태그로 다시 옮길 수 있게 함

### DIFF
--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -168,11 +168,17 @@ router
 router
 /**
  * @openapi
- * /api/tags/merge:
+ * /api/tags/{bookInfoId}/merge:
  *    patch:
  *      description: 태그를 병합한다.
  *      tags:
  *      - tags
+ *      parameters:
+ *      - in: path
+ *        name: bookInfoId
+ *        description: 병합할 책 정보의 id
+ *        required: true
+ *        type: integer
  *      requestBody:
  *        required: true
  *        content:
@@ -253,7 +259,7 @@ router
  *                    type: number
  *                    example: 500
  */
-  .patch('/merge', authValidate(roleSet.librarian), mergeTags);
+  .patch('/:bookInfoId/merge', authValidate(roleSet.librarian), mergeTags);
 
 router
   /**

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -186,7 +186,7 @@ router
  *                  required: true
  *                  example: [1, 2, 3, 5, 10]
  *                superTagId:
- *                  description: 슈퍼 태그의 id
+ *                  description: 슈퍼 태그의 id. null일 경우, 디폴트 태그로 병합됨을 의미한다.
  *                  type: integer
  *                  required: true
  *                  example: 2

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -20,7 +20,8 @@ export const createDefaultTags = async (
   if (await tagsService.isValidBookInfoId(parseInt(bookInfoId, 10)) === false) {
     return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
   }
-  if (content === '' || content.length > 42 || regex.test(content) === true) return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
+  if (content === '' || content.length > 42 || regex.test(content) === true)
+    return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
   await tagsService.createDefaultTags(tokenId, bookInfoId, content);
   return res.status(status.CREATED).send();
 };

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -20,8 +20,7 @@ export const createDefaultTags = async (
   if (await tagsService.isValidBookInfoId(parseInt(bookInfoId, 10)) === false) {
     return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
   }
-  if (content === '' || content.length > 42 || regex.test(content) === true)
-    return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
+  if (content === '' || content.length > 42 || regex.test(content) === true) return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
   await tagsService.createDefaultTags(tokenId, bookInfoId, content);
   return res.status(status.CREATED).send();
 };
@@ -103,21 +102,23 @@ export const mergeTags = async (
   next: NextFunction,
 ) => {
   const { id: tokenId } = req.user as any;
-  const superTagId = parseInt(req?.body?.superTagId, 10);
-  const rawSubTagIds = req?.body?.subTagIds;
-  const subTagIds: number[] = [];
-  rawSubTagIds.forEach((subTagId: string) => {
-    subTagIds.push(parseInt(subTagId, 10));
-  });
+  const bookInfoId: number = req?.body?.bookInfoId;
+  const superTagId: number = req?.body?.superTagId;
+  const subTagIds: number[] = req?.body?.subTagIds;
   const tagsService = new TagsService();
-  if (await tagsService.isDefaultTag(superTagId) === true) {
-    return next(new ErrorResponse(errorCode.DEFAULT_TAG_ID, 400));
+
+  if (await tagsService.isValidBookInfoId(bookInfoId) === false) {
+    return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
   }
-  if (await tagsService.isValidTagIds(subTagIds, superTagId) === false) {
+  if (superTagId !== null
+      && await tagsService.isValidSuperTagId(superTagId, bookInfoId) === false) {
+    return next(new ErrorResponse(errorCode.INVALID_TAG_ID, 400));
+  }
+  if (await tagsService.isValidSubTagId(subTagIds) === false) {
     return next(new ErrorResponse(errorCode.INVALID_TAG_ID, 400));
   }
   try {
-    await tagsService.mergeTags(subTagIds, superTagId, parseInt(tokenId, 10));
+    await tagsService.mergeTags(bookInfoId, subTagIds, superTagId, parseInt(tokenId, 10));
   } catch (e) {
     return next(new ErrorResponse(errorCode.UPDATE_FAIL_TAGS, 500));
   }

--- a/backend/src/tags/tags.repository.ts
+++ b/backend/src/tags/tags.repository.ts
@@ -81,16 +81,6 @@ export class SubTagRepository extends Repository<SubTag> {
       { isPublic, updateUserId: userId, updatedAt: new Date() },
     );
   }
-
-  async getBookInfoIdBySubTagId(subTagId: number) {
-    const subTag = await this.findOne({
-      select: [
-        'bookInfoId',
-      ],
-      where: { id: subTagId },
-    });
-    return subTag?.bookInfoId;
-  }
 }
 
 export class SuperTagRepository extends Repository<SuperTag> {

--- a/backend/src/tags/tags.repository.ts
+++ b/backend/src/tags/tags.repository.ts
@@ -81,6 +81,16 @@ export class SubTagRepository extends Repository<SubTag> {
       { isPublic, updateUserId: userId, updatedAt: new Date() },
     );
   }
+
+  async getBookInfoIdBySubTagId(subTagId: number) {
+    const subTag = await this.findOne({
+      select: [
+        'bookInfoId',
+      ],
+      where: { id: subTagId },
+    });
+    return subTag?.bookInfoId;
+  }
 }
 
 export class SuperTagRepository extends Repository<SuperTag> {

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -134,15 +134,20 @@ export class TagsService {
     await this.subTagRepository.deleteSubTag(subTagsId, deleteUser);
   }
 
-  async isValidTagIds(subTagIds: number[], superTagId: number): Promise<boolean> {
+  async isValidSuperTagId(superTagId: number): Promise<boolean> {
     const superTagCount = await this.superTagRepository.countSuperTag({ id: superTagId });
-    if (superTagCount === 0) {
-      return false;
+    return superTagCount > 0;
+  }
+
+  async isValidSubTagId(subTagId: number | number[]): Promise<boolean> {
+    if (Array.isArray(subTagId)) {
+      const subTagCounts: number[] = await Promise.all(
+        subTagId.map((id) => this.subTagRepository.countSubTag({ id })),
+      );
+      return subTagCounts.every((count) => count > 0);
     }
-    const subTagCounts: number[] = await Promise.all(
-      subTagIds.map((id) => this.subTagRepository.countSubTag({ id })),
-    );
-    return subTagCounts.every((count) => count > 0);
+    const subTagCount = await this.subTagRepository.countSubTag({ id: subTagId });
+    return subTagCount > 0;
   }
 
   async mergeTags(subTagIds: number[], superTagId: number, userId: number) {


### PR DESCRIPTION
### 개요
태그를 병합할 때, 서브 태그를 디폴트 태그로 다시 옮길 수 있게 함

### 작업 사항
슈퍼 태그 id로 null이 들어오면, 서브 태그들을 디폴트 태그로 옮김

### 변경점
- `/api/tags/merge` API
- 태그 컨트롤러에서 `bookInfoId`를 받아서 처리
- 태그 서비스에서 `id` 값 유효성 검사 로직 변경

### 스크린샷 (optional)
