### PR TITLE
bug sub태그 default태그로 머지 시도시 실종됨

### DIFF
--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -104,7 +104,7 @@ export const mergeTags = async (
 ) => {
   const { id: tokenId } = req.user as any;
   const bookInfoId: number = Number(req?.params?.bookInfoId);
-  const superTagId: number = req?.body?.superTagId;
+  const superTagId: number = Number(req?.body?.superTagId);
   const subTagIds: number[] = req?.body?.subTagIds;
   const tagsService = new TagsService();
 

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -103,7 +103,7 @@ export const mergeTags = async (
   next: NextFunction,
 ) => {
   const { id: tokenId } = req.user as any;
-  const bookInfoId: number = req?.body?.bookInfoId;
+  const bookInfoId: number = Number(req?.params?.bookInfoId);
   const superTagId: number = req?.body?.superTagId;
   const subTagIds: number[] = req?.body?.subTagIds;
   const tagsService = new TagsService();

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -245,6 +245,9 @@ export class TagsService {
   }
 
   async isValidBookInfoId(bookInfoId: number): Promise<boolean> {
+    if (bookInfoId === null || bookInfoId === undefined || bookInfoId === 0) {
+      return false;
+    }
     const count: number = await this.superTagRepository.countBookInfoId(bookInfoId);
     if (count === 0) {
       return false;


### PR DESCRIPTION
### 개요
서브 태그를 디폴트 태그로 변경했을 때, 해당 책의 디폴트 태그를 조회하면 그 데이터가 보이지 않음

### 작업 사항
- bookInfoId를 받을 때 request body가 아닌 parameter로 받아 옴
- (추가) bookInfoId 유효성 검사 시, null, undefined, 0은 DB를 거치지 않고 바로 false를 반환하게 함

### 변경점
- tag controller
- tag service

### 목적

### 스크린샷 (optional)
