### PR TITLE
496 patch tagsbookinfoidmerge body 중 supertagid null 값 허용안함

### DIFF
--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -115,6 +115,7 @@ export const mergeTags = async (
   const superTagId: number = Number(req?.body?.superTagId);
   const subTagIds: number[] = req?.body?.subTagIds;
   const tagsService = new TagsService();
+  let returnSuperTagId = 0;
 
   if (await tagsService.isValidBookInfoId(bookInfoId) === false) {
     return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
@@ -127,11 +128,16 @@ export const mergeTags = async (
     return next(new ErrorResponse(errorCode.INVALID_TAG_ID, 400));
   }
   try {
-    await tagsService.mergeTags(bookInfoId, subTagIds, superTagId, parseInt(tokenId, 10));
+    returnSuperTagId = await tagsService.mergeTags(
+      bookInfoId,
+      subTagIds,
+      superTagId,
+      parseInt(tokenId, 10),
+    );
   } catch (e) {
     return next(new ErrorResponse(errorCode.UPDATE_FAIL_TAGS, 500));
   }
-  return res.status(status.OK).send({ id: superTagId });
+  return res.status(status.OK).send({ id: returnSuperTagId });
 };
 
 export const updateSuperTags = async (

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -50,7 +50,7 @@ export const createSuperTags = async (
     return next(new ErrorResponse(errorCode.DUPLICATED_SUPER_TAGS, 400));
   }
   const superTagInsertion = await tagsService.createSuperTags(tokenId, bookInfoId, content);
-  
+
   return res.status(status.CREATED).send(superTagInsertion);
 };
 
@@ -119,7 +119,7 @@ export const mergeTags = async (
   if (await tagsService.isValidBookInfoId(bookInfoId) === false) {
     return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
   }
-  if (superTagId !== null
+  if (superTagId !== 0
       && await tagsService.isValidSuperTagId(superTagId, bookInfoId) === false) {
     return next(new ErrorResponse(errorCode.INVALID_TAG_ID, 400));
   }

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -197,6 +197,7 @@ export class TagsService {
     } finally {
       await this.queryRunner.release();
     }
+    return superTagId;
   }
 
   async isExistingSuperTag(superTagId: number, content: string): Promise<boolean> {

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -118,14 +118,14 @@ export class TagsService {
   }
 
   async createSuperTags(userId: number, bookInfoId: number, content: string) {
-    
+
     let superTagsInsertion: superDefaultTag;
     try {
-      await this.queryRunner.startTransaction(); 
+      await this.queryRunner.startTransaction();
       const superTagId = await this.superTagRepository.createSuperTag(content, bookInfoId, userId);
       const superTag = await this.superTagRepository.getSuperTags({ id: superTagId });
       const superLogin: string | null = await this.superTagRepository.getSuperTagLogin(superTagId);
-      
+
       if (superLogin === null)
         throw new Error(errorCode.CREATE_FAIL_TAGS);
 
@@ -145,7 +145,7 @@ export class TagsService {
     }
     return superTagsInsertion;
   }
-  
+
   async deleteSuperTag(superTagsId: number, deleteUser: number) {
     await this.superTagRepository.deleteSuperTag(superTagsId, deleteUser);
   }
@@ -176,14 +176,14 @@ export class TagsService {
   async mergeTags(
     bookInfoId: number,
     subTagIds: number[],
-    rawSuperTagId: number | null,
+    rawSuperTagId: number,
     userId: number,
   ) {
-    let superTagId: number | null = 0;
+    let superTagId: number = 0;
 
     try {
       await this.queryRunner.startTransaction();
-      if (rawSuperTagId === null) {
+      if (rawSuperTagId === 0) {
         const defaultTag = await this.superTagRepository.getDefaultTag(bookInfoId);
         if (defaultTag === null) {
           superTagId = await this.superTagRepository.createSuperTag('default', bookInfoId, userId);


### PR DESCRIPTION
### 개요
superTagId에 null을 허용했을 때, DB에는 superTagId 값이 0으로 적용됨

### 작업 사항
- superTagId null 검사할 때, `=== null` 대신 `=== 0` 사용
- (추가) 디폴트 태그로의 병합에서 컨트롤러의 리턴 값으로 `superTagId: 0`이 반환되던 것을 `superTagId: defaultTagId`로 수정

### 변경점
- 컨트롤러
- 서비스

### 목적

### 스크린샷 (optional)
