### PR TITLE
500 tag 기능 이용 시 too many connections 발생

### DIFF
--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -18,15 +18,19 @@ export const createDefaultTags = async (
   const tagsService = new TagsService();
   const regex: RegExp = /[^가-힣a-zA-Z0-9_]/g;
   if (content === '' || content.length > 42 || regex.test(content) === true) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
   }
   if (await tagsService.isValidBookInfoId(parseInt(bookInfoId, 10)) === false) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
   }
   if (await tagsService.isDuplicatedSubDefaultTag(content, bookInfoId)) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.DUPLICATED_SUB_DEFAULT_TAGS, 400));
   }
   await tagsService.createDefaultTags(tokenId, bookInfoId, content);
+  await tagsService.releaseConnection();
   return res.status(status.CREATED).send();
 };
 
@@ -41,16 +45,19 @@ export const createSuperTags = async (
   const tagsService = new TagsService();
   const regex: RegExp = /[^가-힣a-zA-Z0-9_]/g;
   if (content === '' || content === 'default' || content.length > 42 || regex.test(content) === true) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
   }
   if (await tagsService.isValidBookInfoId(parseInt(bookInfoId, 10)) === false) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
   }
   if (await tagsService.isDuplicatedSuperTag(content, bookInfoId)) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.DUPLICATED_SUPER_TAGS, 400));
   }
   const superTagInsertion = await tagsService.createSuperTags(tokenId, bookInfoId, content);
-  
+  await tagsService.releaseConnection();
   return res.status(status.CREATED).send(superTagInsertion);
 };
 
@@ -62,6 +69,7 @@ export const deleteSuperTags = async (
   const superTagId = req?.params?.tagId;
   const tagsService = new TagsService();
   await tagsService.deleteSuperTag(parseInt(superTagId, 10), tokenId);
+  await tagsService.releaseConnection();
   return res.status(status.OK).send();
 };
 
@@ -73,6 +81,7 @@ export const deleteSubTags = async (
   const subTagId = req?.params?.tagId;
   const tagsService = new TagsService();
   await tagsService.deleteSubTag(parseInt(subTagId, 10), tokenId);
+  await tagsService.releaseConnection();
   return res.status(status.OK).send();
 };
 
@@ -85,8 +94,14 @@ export const searchSubDefaultTags = async (
   const visibility: string = parseCheck.stringQueryParse(req?.query?.visibility);
   const query: string = parseCheck.stringQueryParse(req?.query?.query);
   const tagsService = new TagsService();
-  return res.status(status.OK)
-    .json(await tagsService.searchSubDefaultTags(page, limit, visibility, query));
+  const subDefaultTags: Object = await tagsService.searchSubDefaultTags(
+    page,
+    limit,
+    visibility,
+    query,
+  );
+  await tagsService.releaseConnection();
+  return res.status(status.OK).json(subDefaultTags);
 };
 
 export const searchSubTags = async (
@@ -94,7 +109,10 @@ export const searchSubTags = async (
   res: Response,
 ) => {
   const superTagId: number = parseInt(req.params.superTagId, 10);
-  return res.status(status.OK).json(await new TagsService().searchSubTags(superTagId));
+  const tagsService = new TagsService();
+  const subTags = await tagsService.searchSubTags(superTagId);
+  await tagsService.releaseConnection();
+  return res.status(status.OK).json(subTags);
 };
 
 export const searchSuperDefaultTags = async (
@@ -102,7 +120,10 @@ export const searchSuperDefaultTags = async (
   res: Response,
 ) => {
   const bookInfoId: number = parseInt(req.params.bookInfoId, 10);
-  return res.status(status.OK).json(await new TagsService().searchSuperDefaultTags(bookInfoId));
+  const tagsService = new TagsService();
+  const superDefaultTags = await tagsService.searchSuperDefaultTags(bookInfoId);
+  await tagsService.releaseConnection();
+  return res.status(status.OK).json(superDefaultTags);
 };
 
 export const mergeTags = async (
@@ -117,19 +138,24 @@ export const mergeTags = async (
   const tagsService = new TagsService();
 
   if (await tagsService.isValidBookInfoId(bookInfoId) === false) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_BOOKINFO_ID, 400));
   }
   if (superTagId !== null
       && await tagsService.isValidSuperTagId(superTagId, bookInfoId) === false) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_TAG_ID, 400));
   }
   if (await tagsService.isValidSubTagId(subTagIds) === false) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_TAG_ID, 400));
   }
   try {
     await tagsService.mergeTags(bookInfoId, subTagIds, superTagId, parseInt(tokenId, 10));
   } catch (e) {
     return next(new ErrorResponse(errorCode.UPDATE_FAIL_TAGS, 500));
+  } finally {
+    await tagsService.releaseConnection();
   }
   return res.status(status.OK).send({ id: superTagId });
 };
@@ -145,18 +171,23 @@ export const updateSuperTags = async (
   const tagsService = new TagsService();
   const regex: RegExp = /[^가-힣a-zA-Z0-9_]/g;
   if (content === '' || content === 'default' || content.length > 42 || regex.test(content) === true) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
   }
   if (await tagsService.isExistingSuperTag(superTagId, content) === true) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.ALREADY_EXISTING_TAGS, 400));
   }
   if (await tagsService.isDefaultTag(superTagId) === true) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.DEFAULT_TAG_ID, 400));
   }
   try {
     await tagsService.updateSuperTags(tokenId, superTagId, content);
   } catch (e) {
     return next(new ErrorResponse(errorCode.UPDATE_FAIL_TAGS, 500));
+  } finally {
+    await tagsService.releaseConnection();
   }
   return res.status(status.OK).send({ id: superTagId });
 };
@@ -171,15 +202,19 @@ export const updateSubTags = async (
   const visibility = req?.body?.visibility;
   const tagsService = new TagsService();
   if (visibility !== 'public' && visibility !== 'private') {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_INPUT_TAGS, 400));
   }
   if (await tagsService.isExistingSubTag(subTagId) === false) {
+    await tagsService.releaseConnection();
     return next(new ErrorResponse(errorCode.INVALID_TAG_ID, 400));
   }
   try {
     await tagsService.updateSubTags(tokenId, subTagId, visibility);
   } catch (e) {
     return next(new ErrorResponse(errorCode.UPDATE_FAIL_TAGS, 500));
+  } finally {
+    await tagsService.releaseConnection();
   }
   return res.status(status.OK).send({ id: subTagId });
 };

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -22,6 +22,10 @@ export class TagsService {
     this.superTagRepository = new SuperTagRepository(this.queryRunner);
   }
 
+  async releaseConnection() {
+    if (this.queryRunner.isReleased === false) await this.queryRunner.release();
+  }
+
   async createDefaultTags(userId: number, bookInfoId: number, content: string) {
     try {
       await this.queryRunner.startTransaction();
@@ -118,16 +122,14 @@ export class TagsService {
   }
 
   async createSuperTags(userId: number, bookInfoId: number, content: string) {
-    
     let superTagsInsertion: superDefaultTag;
     try {
-      await this.queryRunner.startTransaction(); 
+      await this.queryRunner.startTransaction();
       const superTagId = await this.superTagRepository.createSuperTag(content, bookInfoId, userId);
       const superTag = await this.superTagRepository.getSuperTags({ id: superTagId });
       const superLogin: string | null = await this.superTagRepository.getSuperTagLogin(superTagId);
-      
-      if (superLogin === null)
-        throw new Error(errorCode.CREATE_FAIL_TAGS);
+
+      if (superLogin === null) throw new Error(errorCode.CREATE_FAIL_TAGS);
 
       superTagsInsertion = {
         id: superTag[0].id,
@@ -145,7 +147,7 @@ export class TagsService {
     }
     return superTagsInsertion;
   }
-  
+
   async deleteSuperTag(superTagsId: number, deleteUser: number) {
     await this.superTagRepository.deleteSuperTag(superTagsId, deleteUser);
   }


### PR DESCRIPTION
### 개요
- 태그 서비스 객체를 만들 때, 생성자에서 queryRunner를 생성하지만, 객체 사용이 끝나고 따로 release하지 않음

### 작업 사항
- 컨트롤러 내부에서 서비스 객체를 더 이상 쓰지 않아도 될 경우, 따로 queryRunner를 release하는 함수를 호출함

### 변경점
- 태그 서비스 클래스 내 queryRunner 멤버 변수를 release하는 함수 선언
- 서비스 객체의 사용이 끝날 때마다 컨트롤러 내에서 releaseConnection 함수 호출

### 목적

### 스크린샷 (optional)
