### PR TITLE
build: 개발용과 배포용 tsconfig 분리

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,9 +8,9 @@
   "license": "MIT",
   "scripts": {
     "start": "node dist/server.js",
-    "build": "npx tsc -p .",
+    "build": "npx tsc -p ./tsconfig.prod.json",
     "dev": "nodemon --watch \"src/**/*.ts\" --exec \"ts-node\" src/server.ts",
-    "prod": "npx tsc -p . && yarn start",
+    "prod": "npx tsc -p ./tsconfig.prod.json && npm start",
     "lint": "eslint --fix --ext .js,.ts src",
     "test": "jest"
   },

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -100,5 +100,4 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["**/*.spec.ts"]
 }

--- a/backend/tsconfig.prod.json
+++ b/backend/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.spec.ts"],
+}


### PR DESCRIPTION
### 개요

![image](https://github.com/jiphyeonjeon-42/backend/assets/54838975/79f4051f-5ecc-4066-b643-aa970d523652)

- fix #519 

### 작업 사항

- 일반 개발용 `tsconfig.json`과 배포용 `tsconfig.prod.json` (spec.ts 제외)로 분리
- 배포 시 (pnpm prod)  `tsconfig.prod.json` 사용

### 목적
IDE에서 spec.ts 파일에 대해 타입 검사 지원

