### PR TITLE
refactor: config.ts에서 connectOption 사용

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,44 +1,14 @@
 import dotenv from 'dotenv';
+import { connectOption } from './env';
 
 dotenv.config();
-
-let hostName;
-let username;
-let password;
-let database;
-
-switch (process.env.MODE) {
-  case 'local':
-    hostName = 'local';
-    username = process.env.MYSQL_USER;
-    password = process.env.MYSQL_PASSWORD;
-    database = process.env.MYSQL_DATABASE;
-    break;
-  case 'RDS':
-    hostName = process.env.RDS_HOSTNAME;
-    username = process.env.RDS_USERNAME;
-    password = process.env.RDS_PASSWORD;
-    database = process.env.RDS_DB_NAME;
-    break;
-  case 'prod':
-    hostName = 'database';
-    username = process.env.MYSQL_USER;
-    password = process.env.MYSQL_PASSWORD;
-    database = process.env.MYSQL_DATABASE;
-    break;
-  default:
-    hostName = 'database';
-}
 
 const config = {
   nodeEnv: process.env.NODE_ENV,
   mode: process.env.MODE,
   database: {
-    host: hostName,
     port: 3306,
-    username,
-    password,
-    dbName: database,
+    ...connectOption,
   },
   client: {
     id: process.env.CLIENT_ID,

--- a/backend/src/mysql.ts
+++ b/backend/src/mysql.ts
@@ -10,7 +10,7 @@ export const pool = mysql.createPool({
   port: 3306,
   user: config.database.username,
   password: config.database.password,
-  database: config.database.dbName,
+  database: config.database.database,
 });
 
 export const executeQuery = async (queryText: string, values: any[] = []): Promise<any> => {


### PR DESCRIPTION
### 개요

- #513 에서 `config.ts`에도 `connectOption`을 사용하는 것을 놓쳐 추가했습니다.

### 내용

- `app-data-source.ts`와 `config.ts`는 각각 typeorm과 mysql 연결 설정입니다.
-  둘 다 같은 processs.env 값을 사용하므로 `config.ts` 또한 `env.ts`의 `connectOption`을 사용하도록 수정했습니다.
