### PR TITLE
feat: 서버 종료시 점유한 자원 반환

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -54,6 +54,7 @@
     "express": "^4.17.2",
     "http-errors": "^2.0.0",
     "http-status": "^1.5.0",
+    "http-terminator": "^3.2.0",
     "inversify": "^6.0.1",
     "jest-mock-extended": "^3.0.4",
     "jsonwebtoken": "^8.5.1",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   http-status:
     specifier: ^1.5.0
     version: 1.5.0
+  http-terminator:
+    specifier: ^3.2.0
+    version: 3.2.0
   inversify:
     specifier: ^6.0.1
     version: 6.0.1
@@ -1499,7 +1502,6 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-    dev: true
 
   /ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
@@ -1811,6 +1813,10 @@ packages:
       type-is: 1.6.18
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     dev: false
 
   /boxen@5.1.2:
@@ -2354,6 +2360,11 @@ packages:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
+
+  /delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2928,7 +2939,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
@@ -2944,8 +2954,25 @@ packages:
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  /fast-json-stringify@2.7.13:
+    resolution: {integrity: sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      ajv: 6.12.6
+      deepmerge: 4.3.1
+      rfdc: 1.3.0
+      string-similarity: 4.0.4
+    dev: false
+
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  /fast-printf@1.6.9:
+    resolution: {integrity: sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==}
+    engines: {node: '>=10.0'}
+    dependencies:
+      boolean: 3.2.0
+    dev: false
 
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -3259,7 +3286,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       define-properties: 1.2.0
-    dev: true
 
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -3419,6 +3445,16 @@ packages:
   /http-status@1.5.0:
     resolution: {integrity: sha512-wcGvY31MpFNHIkUcXHHnvrE4IKYlpvitJw5P/1u892gMBAM46muQ+RH7UN1d+Ntnfx5apnOnVY6vcLmrWHOLwg==}
     engines: {node: '>= 0.4.0'}
+    dev: false
+
+  /http-terminator@3.2.0:
+    resolution: {integrity: sha512-JLjck1EzPaWjsmIf8bziM3p9fgR1Y3JoUKAkyYEbZmFrIvJM6I8vVJfBGWlEtV9IWOvzNnaTtjuwZeBY2kwB4g==}
+    engines: {node: '>=14'}
+    dependencies:
+      delay: 5.0.0
+      p-wait-for: 3.2.0
+      roarr: 7.15.0
+      type-fest: 2.19.0
     dev: false
 
   /https-proxy-agent@5.0.1:
@@ -4364,7 +4400,6 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: true
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -5144,6 +5179,13 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  /p-wait-for@3.2.0:
+    resolution: {integrity: sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-timeout: 3.2.0
+    dev: false
+
   /package-json@6.5.0:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==}
     engines: {node: '>=8'}
@@ -5639,11 +5681,27 @@ packages:
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
+  /rfdc@1.3.0:
+    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
+    dev: false
+
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
     dependencies:
       glob: 7.2.3
+
+  /roarr@7.15.0:
+    resolution: {integrity: sha512-CV9WefQfUXTX6wr8CrEMhfNef3sjIt9wNhE/5PNu4tNWsaoDNDXqq+OGn/RW9A1UPb0qc7FQlswXRaJJJsqn8A==}
+    engines: {node: '>=12.0'}
+    dependencies:
+      boolean: 3.2.0
+      fast-json-stringify: 2.7.13
+      fast-printf: 1.6.9
+      globalthis: 1.0.3
+      safe-stable-stringify: 2.4.3
+      semver-compare: 1.0.0
+    dev: false
 
   /run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
@@ -5694,6 +5752,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xmlchars: 2.2.0
+
+  /semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+    dev: false
 
   /semver-diff@3.1.1:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
@@ -5940,6 +6002,11 @@ packages:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
+
+  /string-similarity@4.0.4:
+    resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dev: false
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6371,6 +6438,11 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  /type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+    dev: false
+
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -6699,7 +6771,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
-    dev: true
 
   /url-parse-lax@3.0.0:
     resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -14,6 +14,9 @@ dotenv.config();
 
 const runtimeMode = getRuntimeMode(process.env);
 
+// graceful shutdown시 서버 종료 대기 시간
+export const gracefulTerminationTimeout = runtimeMode === 'development' ? 0 : 30 * 1000;
+
 export const logLevelOption = getLogLevelOption(runtimeMode);
 export const connectMode = getModeOption(process.env);
 export const connectOption = getConnectOption(connectMode)(process.env);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,13 @@
+import { createHttpTerminator } from 'http-terminator';
 import app from './app';
+import jipDataSource from './app-data-source';
+import { logger } from './utils/logger';
 import scheduler from './utils/scheduler';
+import { gracefulTerminationTimeout } from './config';
 
 const port = '3000';
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`
   ################################################
   🛡️  Server listening on port: ${port}🛡️
@@ -11,3 +15,24 @@ app.listen(port, () => {
     `);
   scheduler();
 });
+
+const httpTerminator = createHttpTerminator({ server, gracefulTerminationTimeout });
+
+/** 종료 시그널을 받으면 할당된 자원(typeorm DB 연결, 소켓)을 반환하고 서버를 종료합니다. */
+const attemptGracefulShutdown = async (signal: string) => {
+  logger.warn(`Attempting to gracefully shutdown for ${signal}`);
+  if (jipDataSource.isInitialized) {
+    try {
+      await jipDataSource.destroy();
+      logger.warn('successfuly closed typeorm connection to database');
+    } catch (error) {
+      logger.error('error when closing database connection', error);
+    }
+  }
+  await httpTerminator.terminate();
+  logger.warn('closed http server');
+  process.exit(0);
+};
+
+const signals = ['SIGTERM', 'SIGINT', 'SIGUSR2'];
+signals.forEach((signal) => process.on(signal, () => attemptGracefulShutdown(signal)));


### PR DESCRIPTION
### 개요

[http-terminator](https://github.com/gajus/http-terminator) 라이브러리를 사용해 종료 및 재시작 시그널을 받을 시 할당된 자원 (DB, 소켓)을 반환하고 종료하도록 수정하였습니다.

### 목적

#537 에서 벤치마킹중, 재시작 속도가 빨라지자 재시작 시 기존 포트가 이미 점유되어 오류가 발생하는 경우가 많아졌습니다.

<details><summary>오류 로그</summary>

```
2023-06-28 10:12:46:1246 error: uncaughtException: listen EADDRINUSE: address already in use :::3000
Error: listen EADDRINUSE: address already in use :::3000
    at Server.setupListenHandle [as _listen2] (node:net:1823:16)
    at listenInCluster (node:net:1871:12)
    at Server.listen (node:net:1959:7)
    at Function.listen (/home/scarf/repo/lib42/backend/backend/node_modules/.pnpm/express@4.17.2/node_modules/express/lib/application.js:618:24)
    at Object.<anonymous> (/home/scarf/repo/lib42/backend/backend/src/server.ts:10:20)
    at Module._compile (node:internal/modules/cjs/loader:1255:14)
    at Module.m._compile (/home/scarf/repo/lib42/backend/backend/node_modules/.pnpm/ts-node@10.4.0_@types+node@20.3.2_typescript@4.5.5/node_modules/ts-node/src/index.ts:1371:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1309:10)
    at Object.require.extensions.<computed> [as .ts] (/home/scarf/repo/lib42/backend/backend/node_modules/.pnpm/ts-node@10.4.0_@types+node@20.3.2_typescript@4.5.5/node_modules/ts-node/src/index.ts:1374:12)
    at Module.load (node:internal/modules/cjs/loader:1113:32)
 Error Stack: Error: listen EADDRINUSE: address already in use :::3000
    at Server.setupListenHandle [as _listen2] (node:net:1823:16)
    at listenInCluster (node:net:1871:12)
    at Server.listen (node:net:1959:7)
    at Function.listen (/home/scarf/repo/lib42/backend/backend/node_modules/.pnpm/express@4.17.2/node_modules/express/lib/application.js:618:24)
    at Object.<anonymous> (/home/scarf/repo/lib42/backend/backend/src/server.ts:10:20)
    at Module._compile (node:internal/modules/cjs/loader:1255:14)
    at Module.m._compile (/home/scarf/repo/lib42/backend/backend/node_modules/.pnpm/ts-node@10.4.0_@types+node@20.3.2_typescript@4.5.5/node_modules/ts-node/src/index.ts:1371:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1309:10)
    at Object.require.extensions.<computed> [as .ts] (/home/scarf/repo/lib42/backend/backend/node_modules/.pnpm/ts-node@10.4.0_@types+node@20.3.2_typescript@4.5.5/node_modules/ts-node/src/index.ts:1374:12)
    at Module.load (node:internal/modules/cjs/loader:1113:32)
```

</details> 

이는 소켓 등 자원 반환이 올바르지 않게 된 것으로 보아, ['graceful shutdown'](https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html)을 구현했습니다.

### 대안들

- 포트를 점유하는 프로세스를 강제로 죽이기 (`kill (lsof -t -i:3000)`, `kilall node`)
- [nodemon 재시작시 딜레이 주기](https://github.com/remy/nodemon#delaying-restarting) 

하지만 해당 문제는 자원 점유로 인해 발생한 문제이기 때문에 할당받은 자원을 해제해주는 식으로 구현하는 것이 옳다 생각했습니다.

- node 18.2.0에 추가된 [`server.closeAllConnections()`](https://nodejs.org/api/http.html#servercloseallconnections)

현재 [배포 서버 노드 버전](https://github.com/jiphyeonjeon-42/backend/blob/c3f6910045419ab2ae621cd57d051af9f4e38719/.github/workflows/main.yml#L48)이 낮고 (16), 생각만큼 안정적으로 동작하지 않아 express 공식 문서에서 소개하는 방법 중 http-terminator 라이브러리를 택했습니다.

### 참고 링크

- https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html#http-terminator
- https://stackoverflow.com/questions/63634210/eaddrinuse-gets-generated-on-every-save-with-nodemon
- https://stackoverflow.com/questions/14515954/how-to-properly-close-node-js-express-server