### PR TITLE
fix: review 스키마 타입 검증 완화,  disabled 필드 기본값 추가

### DIFF
--- a/backend/src/reviews/controller/reviews.type.ts
+++ b/backend/src/reviews/controller/reviews.type.ts
@@ -21,7 +21,7 @@ type Disabled = 0 | 1 | -1;
 const disabledSchema = z.coerce.number().int().refine(
   (n): n is Disabled => [-1, 0, 1].includes(n),
   (n) => ({ message: `0: 공개, 1: 비공개, -1: 전체 리뷰, 입력값: ${n}` }),
-);
+).default(-1);
 
 export const queryOptionSchema = z.object({
   page: positiveInt.default(0),
@@ -29,8 +29,13 @@ export const queryOptionSchema = z.object({
   sort: sortSchema,
 });
 
+export const booleanLikeSchema = z.union([
+  z.boolean(),
+  z.string().toLowerCase().refine((s) => s === 'true'),
+]);
+
 export const getReviewsSchema = z.object({
-  isMyReview: z.boolean().default(false),
+  isMyReview: booleanLikeSchema.catch(false),
   titleOrNickname: z.string().optional(),
   disabled: disabledSchema,
 }).merge(queryOptionSchema);


### PR DESCRIPTION
### 개요

![개발자 도구 - 집현전 - http:__localhost:4242_mypage_01](https://github.com/jiphyeonjeon-42/backend/assets/54838975/125df942-233e-4772-a2c9-fbc1868b37f2)

- fixes #546 

### 작업 사항

```jsonc
// req.params
{
  "limit": "5",
  "page": "0",
  "isMyReview": "true"
}
```

프론트 요청 확인 결과

- 필드가 모두 string 타입으로 들어오고 있으나 백엔드에서는 number 또는 boolean을 기대하고 있어 문제가 발생했습니다.
- disabled 필드의 기본값 부분이 누락되어 있었습니다.

