### PR TITLE
refactor: reviews 레포지토리 queryBuilder를 find와 count로 이전

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -71,6 +71,7 @@
     "reflect-metadata": "^0.1.13",
     "swagger-jsdoc": "^6.1.0",
     "swagger-ui-express": "^4.3.0",
+    "ts-pattern": "^5.0.1",
     "tsconfig-paths": "^4.1.1",
     "typeorm": "^0.3.11",
     "typeorm-model-generator": "^0.4.6",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -83,6 +83,9 @@ dependencies:
   swagger-ui-express:
     specifier: ^4.3.0
     version: 4.3.0(express@4.17.2)
+  ts-pattern:
+    specifier: ^5.0.1
+    version: 5.0.1
   tsconfig-paths:
     specifier: ^4.1.1
     version: 4.1.1
@@ -6421,6 +6424,10 @@ packages:
       typescript: 5.0.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  /ts-pattern@5.0.1:
+    resolution: {integrity: sha512-ZyNm28Lsg34Co5DS3e9DVyjlX2Y+2exkI4jqTKyU+9/OL6Y2fKOOuL8i+7no71o74C6mVS+UFoP3ekM3iCT1HQ==}
+    dev: false
 
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}

--- a/backend/src/DTO/index.ts
+++ b/backend/src/DTO/index.ts
@@ -1,0 +1,4 @@
+export * from './common.interface';
+export * from './reviews.model';
+export * from './tags.model';
+export * from './users.model';

--- a/backend/src/DTO/reviews.model.ts
+++ b/backend/src/DTO/reviews.model.ts
@@ -1,0 +1,11 @@
+export type Review = {
+  bookInfoId: number;
+  content: string;
+  createdAt: Date;
+  disabled: boolean;
+  intraId: number | null;
+  nickname: string | null;
+  reviewerId: number;
+  reviewsId: number;
+  title: string;
+};

--- a/backend/src/books/books.repository.ts
+++ b/backend/src/books/books.repository.ts
@@ -147,40 +147,44 @@ class BooksRepository extends Repository<Book> {
       .getRawOne();
   }
 
-  async updateBookInfo(bookInfo: UpdateBookInfo): Promise<void> {
-    await this.bookInfo.update(bookInfo.id, bookInfo as BookInfo);
+  async updateBookInfo({
+    id, categoryId, ...rest
+  }: UpdateBookInfo): Promise<void> {
+    await this.bookInfo.update(id, {
+      id,
+      categoryId: Number(categoryId),
+      ...rest,
+    });
   }
 
   async updateBook(book: UpdateBook): Promise<void> {
     await this.books.update(book.id, book as Book);
   }
 
-  async createBookInfo(
-    target: CreateBookInfo,
-  ): Promise<BookInfo> {
-    const bookInfo: BookInfo = {
-      title: target.title,
-      author: target.author,
-      publisher: target.publisher,
-      publishedAt: target.pubdate,
-      categoryId: Number(target.categoryId),
-      isbn: target.isbn,
-      image: target.image,
-    };
-    return this.bookInfo.save(bookInfo);
+  async createBookInfo({
+    title, author, publisher, pubdate, categoryId, isbn, image,
+  }: CreateBookInfo): Promise<BookInfo> {
+    return this.bookInfo.save({
+      title,
+      author,
+      publisher,
+      publishedAt: pubdate,
+      categoryId: Number(categoryId),
+      isbn,
+      image,
+    });
   }
 
-  async createBook(
-    target: CreateBookInfo,
-  ): Promise<void> {
-    const book: Book = {
-      donator: target.donator,
-      donatorId: target.donatorId,
-      callSign: target.callSign,
+  async createBook({
+    donator, donatorId, callSign, infoId,
+  }: CreateBookInfo): Promise<void> {
+    await this.books.save({
+      donator,
+      donatorId,
+      callSign,
+      infoId,
       status: 0,
-      infoId: target.infoId,
-    };
-    await this.books.save(book);
+    });
   }
 }
 

--- a/backend/src/books/books.type.ts
+++ b/backend/src/books/books.type.ts
@@ -42,7 +42,7 @@ export type UpdateBookInfo = {
   title: string;
   author: string;
   publisher: string;
-  publishedAt: string | Date;
+  publishedAt: string;
   image: string;
   categoryId?: string;
 }

--- a/backend/src/entity/entities/Book.ts
+++ b/backend/src/entity/entities/Book.ts
@@ -11,7 +11,7 @@ import Reservation from './Reservation';
 
 class Book {
   @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
-    id?: number;
+    id: number;
 
   @Column('varchar', { name: 'donator', nullable: true, length: 255 })
     donator: string | null;
@@ -26,7 +26,7 @@ class Book {
     name: 'createdAt',
     default: () => "'CURRENT_TIMESTAMP(6)'",
   })
-    createdAt?: Date;
+    createdAt: Date;
 
   @Column()
     infoId: number;

--- a/backend/src/entity/entities/BookInfo.ts
+++ b/backend/src/entity/entities/BookInfo.ts
@@ -12,16 +12,16 @@ import SuperTag from './SuperTag';
 @Entity('book_info')
 class BookInfo {
   @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
-    id?: number;
+    id: number;
 
   @Column('varchar', { name: 'title', length: 255 })
-    title?: string;
+    title: string;
 
   @Column('varchar', { name: 'author', length: 255 })
-    author?: string;
+    author: string;
 
   @Column('varchar', { name: 'publisher', length: 255 })
-    publisher?: string;
+    publisher: string;
 
   @Column('varchar', { name: 'isbn', nullable: true, length: 255 })
     isbn?: string | null;
@@ -36,38 +36,38 @@ class BookInfo {
     name: 'createdAt',
     default: () => "'CURRENT_TIMESTAMP(6)'",
   })
-    createdAt?: Date;
+    createdAt: Date;
 
   @Column('datetime', {
     name: 'updatedAt',
     default: () => "'CURRENT_TIMESTAMP(6)'",
   })
-    updatedAt?: Date;
+    updatedAt: Date;
 
   @Column('int', { name: 'categoryId' })
-    categoryId?: number;
+    categoryId: number;
 
   @OneToMany(() => Book, (book) => book.info)
-    books?: Book[];
+    books: Book[];
 
   @ManyToOne(() => Category, (category) => category.bookInfos, {
     onDelete: 'NO ACTION',
     onUpdate: 'NO ACTION',
   })
   @JoinColumn([{ name: 'categoryId', referencedColumnName: 'id' }])
-    category?: Category;
+    category: Category;
 
   @OneToMany(() => Likes, (likes) => likes.bookInfo)
-    likes?: Likes[];
+    likes: Likes[];
 
   @OneToMany(() => Reservation, (reservation) => reservation.bookInfo)
-    reservations?: Reservation[];
+    reservations: Reservation[];
 
   @OneToMany(() => Reviews, (reviews) => reviews.bookInfo)
-    reviews?: Reviews[];
+    reviews: Reviews[];
 
   @OneToMany(() => SuperTag, (superTags) => superTags.userId)
-    superTags?: SuperTag[];
+    superTags: SuperTag[];
 }
 
 export default BookInfo;


### PR DESCRIPTION
## 개요

- getReviewsPage에서 DTO 대신 엔티티를 반환하도록 변경했습니다.
- 기존 쿼리 또한 실행하고 비교해 동작의 차이가 없음을 확인했습니다.

## 남은 작업
- 런타임에 확인하는 대신 spec.ts로 분리해 테스트하도록 변경해야 합니다.

## 선행 PR

- #552
- #554
- #553

