### PR TITLE
fix: `VLendingForSearchUser` 쿼리러너 통합

### DIFF
--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -30,8 +30,7 @@ export default class UsersRepository extends Repository<User> {
     );
     this.lendingForSearchUserRepo = new Repository<VLendingForSearchUser>(
       VLendingForSearchUser,
-      jipDataSource.createEntityManager(),
-      jipDataSource.createQueryRunner(),
+      manager,
     );
     this.reservationsRepo = new Repository<Reservation>(
       Reservation,


### PR DESCRIPTION
users 저장소에서 혼자서 다른 쿼리러너를 사용중이어서 올바르게 자원 해제가 되지 않고 있었습니다.
