### PR TITLE
ci: 빌드 가능 여부 테스트

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,22 +8,23 @@ permissions:
     contents: write
 defaults:
   run:
-    working-directory: docs 
+    working-directory: docs
 
 jobs:
-  deploy:
+  docs:
+    name: Deploy Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           clear-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: Test PR
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: setup node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest-8 --activate
+          pnpm config set store-dir .pnpm-store
+
+      - name: install dependencies
+        working-directory: backend
+        run: pnpm install
+
+      - name: build backend
+        working-directory: backend
+        run: pnpm build
+
+      # TODO: 테스트 실행

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -15,7 +15,7 @@ dotenv.config();
 const runtimeMode = getRuntimeMode(process.env);
 
 // graceful shutdown시 서버 종료 대기 시간
-export const gracefulTerminationTimeout = runtimeMode === 'development' ? 0 : 30 * 1000;
+export const gracefulTerminationTimeout = runtimeMode === 'production' ? 30 * 1000 : 0;
 
 export const logLevelOption = getLogLevelOption(runtimeMode);
 export const connectMode = getModeOption(process.env);

--- a/backend/src/config/logOption.ts
+++ b/backend/src/config/logOption.ts
@@ -18,7 +18,7 @@ export const colors: Record<LogLevel, string> = {
 } as const;
 
 export const getLogLevelOption = (mode: RuntimeMode): LogLevelOption => {
-  const logLevel = (mode === 'development' ? 'debug' : 'http');
+  const logLevel = (mode === 'production' ? 'http' : 'debug');
   const consoleLogLevel = (mode === 'production' ? 'error' : 'debug');
 
   return { logLevel, consoleLogLevel } as const;

--- a/backend/src/config/runtimeOption.ts
+++ b/backend/src/config/runtimeOption.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export type RuntimeMode = z.infer<typeof runtimeModeSchema>;
-export const runtimeModeSchema = z.enum(['development', 'production']);
+export const runtimeModeSchema = z.enum(['development', 'production', 'test']);
 
 export const runtimeSchema = z.object({ NODE_ENV: runtimeModeSchema.default('development') });
 


### PR DESCRIPTION
# 개요

develop을 main에 머지하기 전에 PR이 CI 환경에서 빌드가 가능한지 확인합니다.

## 변경점

- jest 등 테스트 프레임워크 실행시 `NodeEnv` 환경변수에 `test` 값이 들어가는 것을 확인해, config environment 스키마에 추가해주었습니다.
- 기존 대기시간, 로그레벨 등은 development와 production만 가정했는데, test도 고려해
	- 로그 레벨은 production은 http, development와 test는  debug 모드로,
	- 서버 종료 대기 시간은 production만 30초 대기, development와 test는 대기하지 않는 식으로 바꾸었습니다.