### PR TITLE
fix: tag 중복 검사 시, 삭제되지 않은 것에서 검사

### DIFF
--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -37,9 +37,13 @@ export class TagsService {
       } else {
         defaultTagId = defaultTag.id;
       }
-      const subTagId = await this.subTagRepository.createDefaultTags(userId, bookInfoId, content, defaultTagId);
+      const subTagId = await this.subTagRepository.createDefaultTags(
+        userId,
+        bookInfoId,
+        content,
+        defaultTagId,
+      );
       const subTag = await this.subTagRepository.getSubTags({ id: subTagId });
-
       defaultTagsInsertion = {
         id: subTag[0].id,
         content: subTag[0].content,
@@ -54,7 +58,6 @@ export class TagsService {
     } finally {
       await this.queryRunner.release();
     }
-
     return defaultTagsInsertion;
   }
 
@@ -293,6 +296,7 @@ export class TagsService {
     const subDefaultTag: VTagsSubDefault[] = await this.subTagRepository.getSubTags({
       content,
       bookInfoId,
+      isDeleted: 0,
     });
     if (subDefaultTag.length === 0) {
       return false;
@@ -304,6 +308,7 @@ export class TagsService {
     const superTag: SuperTag[] = await this.superTagRepository.getSuperTags({
       content,
       bookInfoId,
+      isDeleted: 0,
     });
     if (superTag.length === 0) {
       return false;


### PR DESCRIPTION
### 개요
tag 중복 검사 시, where 절에 삭제되지 않은 것에서 검사하도록 변경

### 작업 사항
태그 생성 시, 중복 검사하는 함수에 `isDeleted: 0` 조건 추가

### 목적

### 스크린샷 (optional)

### 비고
- content와 작성자가 똑같은 태그가 다시 생성될 때, 이미 해당 데이터가 DB에 존재하여 `isDeleted`와 `updatedAt`, `updateUserId`만 바꿔주면 되는 방법도 있음
- 현재 방법은 이미 soft delete된 데이터는 재사용하지 않는 방식