### PR TITLE
feat: 태그 관리자 용의 api 분리

### DIFF
--- a/backend/src/v1/routes/tags.routes.ts
+++ b/backend/src/v1/routes/tags.routes.ts
@@ -638,7 +638,7 @@ router
    *    get:
    *      tags:
    *      - tags
-   *      summary: 슈퍼 태그에 속한 서브 태그 목록을 가져온다.
+   *      summary: 슈퍼 태그에 속한 서브 태그 목록을 가져온다. 이는 일반 사용자를 위해 사용된다.
    *      description: superTagId에 해당하는 슈퍼 태그에 속한 서브 태그 목록을 가져온다. 태그 병합 페이지에서 슈퍼 태그의
    *                   서브 태그를 가져올 때 사용한다.
    *      parameters:
@@ -686,7 +686,64 @@ router
    *        '500':
    *          description: db 에러
    */
-  .get('/:superTagId/sub', authValidate(roleSet.librarian), searchSubTags);
+  .get('/:superTagId/sub', authValidate(roleSet.all), searchSubTags);
+
+router
+  /**
+   * @openapi
+   * /api/tags/manage/{superTagId}/sub:
+   *    get:
+   *      tags:
+   *      - tags
+   *      summary: 슈퍼 태그에 속한 서브 태그 목록을 가져온다. 이는 태그 관리를 위해 사용된다.
+   *      description: superTagId에 해당하는 슈퍼 태그에 속한 서브 태그 목록을 가져온다. 태그 병합 페이지에서 슈퍼 태그의
+   *                   서브 태그를 가져올 때 사용한다.
+   *      parameters:
+   *        - in: path
+   *          name: superTagId
+   *          description: 서브 태그를 조회할 슈퍼 태그의 id
+   *          required: true
+   *      responses:
+   *        '200':
+   *          description: 슈퍼 태그에 속한 서브 태그들을 반환한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 슈퍼 태그에 속한 서브 태그 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        id:
+   *                          description: 서브 태그 고유 id
+   *                          type: integer
+   *                        content:
+   *                          description: 서브 태그의 내용
+   *                          type: string
+   *                        login:
+   *                          description: 서브 태그를 작성한 카뎃의 인트라 id
+   *                          type: string
+   *                    example:
+   *                    - id: 0
+   *                      content: 도커_쿠버네티스
+   *                      login: yena
+   *                    - id: 42
+   *                      content: 도커
+   *                      login: yena
+   *                    - id: 50
+   *                      content: 도커
+   *                      login: jang-cho
+   *        '400':
+   *          description: 잘못된 요청. 잘못 입력된 json key, 유효하지 않은 value 등
+   *        '401':
+   *          description: 태그 기록을 조회할 권한이 없는 사용자
+   *        '500':
+   *          description: db 에러
+   */
+  .get('/manage/:superTagId/sub', authValidate(roleSet.librarian), searchSubTags);
 
 router
   /**


### PR DESCRIPTION
### 개요
태그 관리자 용의 api와 일반 사용자 용 api로 분리

### 작업 사항
`/api/tags/{superTagId}/sub` GET을
- 일반 사용자 용: `/api/tags/{superTagId}/sub`
- 태그 관리자 용: `/api/tags/manage/{superTagId}/sub`

로 분리하였습니다. 내부 함수 로직은 같으나, 추후 태그 관리자나 일반 사용자에 따라 로직의 변경이 일어날 시, 변경 사항 적용을 용이하게 하기 위해 위와 같이 작업하였습니다.
