### PR TITLE
build: 프로덕션에서도 ts-node 사용

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,10 +10,10 @@
     "node": ">=20.3.1 || >=18.16.1 <20.0.0"
   },
   "scripts": {
-    "start": "node dist/server.js",
-    "build": "npx tsc -p ./tsconfig.prod.json",
-    "dev": "nodemon --watch \"src/**/*.ts\" --exec \"ts-node\" -r tsconfig-paths/register src/server.ts",
-    "prod": "npx tsc -p ./tsconfig.prod.json && npm start",
+    "start": "ts-node -r tsconfig-paths/register --project ./tsconfig.prod.json src/server.ts",
+    "build": "echo '번들러 사용중이지 않아 빌드시 tsconfig paths 적용이 불가합니다' && exit 1",
+    "dev": "nodemon --watch \"src/**/*.ts\" --exec ts-node -r tsconfig-paths/register src/server.ts",
+    "prod": "pnpm start",
     "lint": "eslint --fix --ext .js,.ts src",
     "test": "jest"
   },


### PR DESCRIPTION
### 개요

프로덕션에서도 빌드하지 않고 ts-node를 사용해 서버를 실행합니다.

- tsc에서 paths를 변경하지 않아 빌드 후 실행이 불가능합니다.
- 추후 번들러로 변경해야 합니다.

### 추후 해결점

메모리 사용량이 빌드 전보다 3~4배가량 높게 나오는 문제가 있으나, 현재 lightsail 가용 메모리 범위 내에 있는 것 같습니다.