### PR TITLE
ci: ts-node를 프로덕션에서 사용 (part 2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,10 @@ jobs:
         working-directory: backend
         run: pnpm install
 
-      - name: build backend
-        working-directory: backend
-        run: pnpm build
+      # TODO(@scarf005): #594
+      # - name: build backend
+      #   working-directory: backend
+      #   run: pnpm build
 
       - name: create .env file
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,9 @@ jobs:
         working-directory: backend
         run: pnpm install
 
-      - name: build backend
-        working-directory: backend
-        run: pnpm build
+      # TODO(@scarf005): #594
+      # - name: build backend
+      #   working-directory: backend
+      #   run: pnpm build
 
       # TODO: 테스트 실행

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,10 @@ RUN npm install --global pnpm
 COPY . .
 RUN pnpm install
 
-RUN pnpm install --global pm2
-RUN pm2-runtime --version || exit 1
+ENTRYPOINT [ "pnpm", "prod" ]
 
-ENTRYPOINT [ "sh", "start.sh"]
+# RUN pnpm install --global pm2
+# RUN pm2-runtime --version || exit 1
+
+# TODO(@scarf005): #594
+# ENTRYPOINT [ "sh", "start.sh"]


### PR DESCRIPTION
### 개요

- #594 에서 배포 스크립트도 함께 수정하는 것을 놓쳐 다시 올립니다.

### 변경점

- 배포 단계에서 build 단계를 주석 처리했습니다.
- start.sh 대신 `pnpm prod`를 바로 실행하게 변경했습니다.
