### PR TITLE
refactor: reviews `impl.ts`을 역할에 따라 분리

### DIFF
--- a/backend/src/v2/reviews/controller/controller.ts
+++ b/backend/src/v2/reviews/controller/controller.ts
@@ -7,9 +7,9 @@ import {
   bookInfoNotFound,
   getUser,
   reviewNotFound,
-} from '../shared';
-import { ReviewsService } from './service';
-import { ReviewNotFoundError } from './service/errors';
+} from '../../shared';
+import { ReviewsService } from '../service';
+import { ReviewNotFoundError } from '../service/errors';
 
 type PostDeps = Pick<ReviewsService, 'createReview'>;
 type MkPost = (services: PostDeps) => HandlerFor<typeof contract.reviews.post>;
@@ -21,11 +21,15 @@ export const mkPostReviews: MkPost =
 
     return match(result)
       .with(P.instanceOf(BookInfoNotFoundError), () => bookInfoNotFound)
-      .otherwise(() => ({ status: 201, body: '리뷰가 작성되었습니다.' } as const));
+      .otherwise(
+        () => ({ status: 201, body: '리뷰가 작성되었습니다.' } as const),
+      );
   };
 
 type PatchDeps = Pick<ReviewsService, 'toggleReviewVisibility'>;
-type MkPatch = (services: PatchDeps) => HandlerFor<typeof contract.reviews.patch>;
+type MkPatch = (
+  services: PatchDeps,
+) => HandlerFor<typeof contract.reviews.patch>;
 export const mkPatchReviews: MkPatch =
   ({ toggleReviewVisibility }) =>
   async ({ params: { reviewsId }, req: { user } }) => {
@@ -34,7 +38,13 @@ export const mkPatchReviews: MkPatch =
 
     return match(result)
       .with(P.instanceOf(ReviewNotFoundError), () => reviewNotFound)
-      .otherwise(() => ({ status: 200, body: '리뷰 공개 여부가 업데이트되었습니다.' } as const));
+      .otherwise(
+        () =>
+          ({
+            status: 200,
+            body: '리뷰 공개 여부가 업데이트되었습니다.',
+          } as const),
+      );
   };
 
 type PutDeps = Pick<ReviewsService, 'updateReview'>;
@@ -54,7 +64,9 @@ export const mkPutReviews: MkPut =
   };
 
 type DeleteDeps = Pick<ReviewsService, 'removeReview'>;
-type MkDelete = (services: DeleteDeps) => HandlerFor<typeof contract.reviews.delete>;
+type MkDelete = (
+  services: DeleteDeps,
+) => HandlerFor<typeof contract.reviews.delete>;
 export const mkDeleteReviews: MkDelete =
   ({ removeReview }) =>
   async ({ params: { reviewsId }, req: { user } }) => {

--- a/backend/src/v2/reviews/controller/impl.ts
+++ b/backend/src/v2/reviews/controller/impl.ts
@@ -1,0 +1,14 @@
+import { ReviewsService } from '../service';
+import {
+  mkDeleteReviews,
+  mkPatchReviews,
+  mkPostReviews,
+  mkPutReviews,
+} from './controller';
+
+export const implReviewController = (service: ReviewsService) => ({
+  post: mkPostReviews(service),
+  patch: mkPatchReviews(service),
+  put: mkPutReviews(service),
+  delete: mkDeleteReviews(service),
+});

--- a/backend/src/v2/reviews/controller/index.ts
+++ b/backend/src/v2/reviews/controller/index.ts
@@ -1,0 +1,1 @@
+export * from "./controller";

--- a/backend/src/v2/reviews/impl.ts
+++ b/backend/src/v2/reviews/impl.ts
@@ -7,7 +7,12 @@ import { roleSet } from '~/v1/auth/auth.type';
 import authValidate from '~/v1/auth/auth.validate';
 
 import { Repository } from 'typeorm';
-import { mkDeleteReviews, mkPatchReviews, mkPostReviews, mkPutReviews } from './controller';
+import {
+  mkDeleteReviews,
+  mkPatchReviews,
+  mkPostReviews,
+  mkPutReviews,
+} from './controller';
 import {
   ReviewsService as ReviewService,
   mkCreateReview,

--- a/backend/src/v2/reviews/impl.ts
+++ b/backend/src/v2/reviews/impl.ts
@@ -1,35 +1,19 @@
 import { contract } from '@jiphyeonjeon-42/contracts';
 import { initServer } from '@ts-rest/express';
-import jipDataSource from '~/app-data-source';
-import BookInfo from '~/entity/entities/BookInfo';
-import Reviews from '~/entity/entities/Reviews';
 import { roleSet } from '~/v1/auth/auth.type';
 import authValidate from '~/v1/auth/auth.validate';
 
-import { Repository } from 'typeorm';
+import jipDataSource from '~/app-data-source';
+import BookInfo from '~/entity/entities/BookInfo';
+import Reviews from '~/entity/entities/Reviews';
 import {
   mkDeleteReviews,
   mkPatchReviews,
   mkPostReviews,
   mkPutReviews,
 } from './controller';
-import {
-  ReviewsService as ReviewService,
-  mkCreateReview,
-  mkRemoveReview,
-  mkToggleReviewVisibility,
-  mkUpdateReview,
-} from './service';
-
-const implReviewService = (repos: {
-  reviews: Repository<Reviews>;
-  bookInfo: Repository<BookInfo>;
-}) => ({
-  createReview: mkCreateReview(repos),
-  removeReview: mkRemoveReview(repos),
-  updateReview: mkUpdateReview(repos),
-  toggleReviewVisibility: mkToggleReviewVisibility(repos),
-});
+import { ReviewsService as ReviewService } from './service';
+import { implReviewService } from './service/impl';
 
 const implReviewController = (service: ReviewService) => ({
   post: mkPostReviews(service),
@@ -43,7 +27,7 @@ const service = implReviewService({
   bookInfo: jipDataSource.getRepository(BookInfo),
 });
 
-const handler = implReviewController(service);
+export const handler = implReviewController(service);
 
 const s = initServer();
 export const reviews = s.router(contract.reviews, {

--- a/backend/src/v2/reviews/impl.ts
+++ b/backend/src/v2/reviews/impl.ts
@@ -6,28 +6,14 @@ import authValidate from '~/v1/auth/auth.validate';
 import jipDataSource from '~/app-data-source';
 import BookInfo from '~/entity/entities/BookInfo';
 import Reviews from '~/entity/entities/Reviews';
-import {
-  mkDeleteReviews,
-  mkPatchReviews,
-  mkPostReviews,
-  mkPutReviews,
-} from './controller';
-import { ReviewsService as ReviewService } from './service';
+import { implReviewController } from './controller/impl';
 import { implReviewService } from './service/impl';
-
-const implReviewController = (service: ReviewService) => ({
-  post: mkPostReviews(service),
-  patch: mkPatchReviews(service),
-  put: mkPutReviews(service),
-  delete: mkDeleteReviews(service),
-});
 
 const service = implReviewService({
   reviews: jipDataSource.getRepository(Reviews),
   bookInfo: jipDataSource.getRepository(BookInfo),
 });
-
-export const handler = implReviewController(service);
+const handler = implReviewController(service);
 
 const s = initServer();
 export const reviews = s.router(contract.reviews, {

--- a/backend/src/v2/reviews/service/impl.ts
+++ b/backend/src/v2/reviews/service/impl.ts
@@ -1,0 +1,19 @@
+import { Repository } from 'typeorm';
+import type BookInfo from '~/entity/entities/BookInfo';
+import type Reviews from '~/entity/entities/Reviews';
+import {
+  mkCreateReview,
+  mkRemoveReview,
+  mkToggleReviewVisibility,
+  mkUpdateReview,
+} from './service';
+
+export const implReviewService = (repos: {
+  reviews: Repository<Reviews>;
+  bookInfo: Repository<BookInfo>;
+}) => ({
+  createReview: mkCreateReview(repos),
+  removeReview: mkRemoveReview(repos),
+  updateReview: mkUpdateReview(repos),
+  toggleReviewVisibility: mkToggleReviewVisibility(repos),
+});


### PR DESCRIPTION
### 개요

- resolves #601
- resolves #600

### 작업 사항

기존 impl.ts는 
- 서비스 의존성 (typeorm repository) 주입
- 컨트롤러 의존성 (서비스) 주입
- ts-rest 라우터 의존성 (컨트롤러) 주입

을 하나의 파일에서 진행했기 때문에 한 번에 한 가지 기능만 수행하도록 service와 controller 경로로 impl.ts 파일을 쪼갰습니다.