### PR TITLE
fix: Dockerfile 올바르지 않은 작업 경로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install --global pnpm
 RUN pnpm config set store-dir .pnpm-store
 RUN pnpm install --global node-pre-gyp
 
-WORKDIR /backend
+WORKDIR /app
 
 FROM pnpm-installed as workspace
 COPY ./pnpm-lock.yaml .
@@ -21,6 +21,7 @@ ADD . ./
 RUN pnpm -r install --frozen-lockfile --offline
 RUN pnpm -r run build
 
-# WORKDIR /backend
+WORKDIR /app/backend
+
 EXPOSE 3000
 ENTRYPOINT [ "pnpm", "prod" ]

--- a/appspec.yml
+++ b/appspec.yml
@@ -2,7 +2,7 @@ version: 0.0
 os: linux
 
 files:
-  - source:  /
+  - source: /
     destination: /home/ec2-user/backend-express
     overwrite: true
 file_exists_behavior: OVERWRITE


### PR DESCRIPTION
### 개요

- 도커파일 빌드시 작업 경로를 루트 경로 `/` 대신 `/app`으로 설정해 컨테이너 내부 루트 파일을 수정하는 일이 없도록 변경
- entrypoint에서 `pnpm prod` 실행시 작업 경로가 backend/ 하위 경로로 설정되지 않던 문제 수정