### PR TITLE
fix: nginx에서 `swagger/`와 `swagger-v2/` 경로 허용

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -65,11 +65,13 @@ const v2Specs = generateOpenApi(
     setOperationId: false,
   },
 );
-app.get('/docs.json', (_req, res) => res.json(v2Specs));
+
+const v2JsonPath = '/swagger-v2/openapi.json';
+app.get(v2JsonPath, (_req, res) => res.json(v2Specs));
 app.use(
-  '/docs',
-  swaggerUi.serveFiles(undefined, { swaggerUrl: '/docs.json' }),
-  swaggerUi.setup(undefined, { explorer: true, swaggerUrl: '/docs.json' }),
+  '/swagger-v2',
+  swaggerUi.serveFiles(undefined, { swaggerUrl: v2JsonPath }),
+  swaggerUi.setup(undefined, { explorer: true, swaggerUrl: v2JsonPath }),
 );
 
 // dev route

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -45,11 +45,12 @@ passport.use('jwt', JwtStrategy);
 
 // Swagger 연결
 const specs = swaggerJsdoc(swaggerOptions);
-app.get('/swagger.json', (_req, res) => res.json(specs));
+const v1JsonPath = '/swagger/openapi.json';
+app.get(v1JsonPath, (_req, res) => res.json(specs));
 app.use(
   '/swagger',
-  swaggerUi.serveFiles(undefined, { swaggerUrl: '/swagger.json' }),
-  swaggerUi.setup(undefined, { explorer: true, swaggerUrl: '/swagger.json' }),
+  swaggerUi.serveFiles(undefined, { swaggerUrl: v1JsonPath }),
+  swaggerUi.setup(undefined, { explorer: true, swaggerUrl: v1JsonPath }),
 );
 
 const v2Specs = generateOpenApi(

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -17,6 +17,15 @@ server {
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
     }
+    location /swagger-v2/ {
+           auth_basic "Admin page (V2)";
+           auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+           proxy_pass http://backend:3000;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
     #error_page  404              /404.html;
 


### PR DESCRIPTION
### 개요

![image](https://github.com/jiphyeonjeon-42/backend/assets/54838975/44f2ecea-ce90-47f1-ba03-27346d556216)

- fixes #639 

배포 서버에서 v1과 v2 swagger 문서를 볼 수 있게 수정합니다.
### 변경점

일관성을 위해 `/docs` 경로명을 `/swagger-v2`로 변경했습니다.

### 작업 사항

1. nginx 설정 파일에서 /swagger-v2/ 경로를 노출했습니다.
2. `swagger.json`과 `docs.json`의 경로를 `swagger/openapi.json`과 `swagger-v2/openapi.json`으로 변경했습니다.

### `/swagger`와 `/swagger-v2` 경로를 나눈 이유

`/swagger/v2` 경로를 사용해 nginx 설정 중복을 피하려 했으나 v1 swagger 경로와 겹쳐 사용이 불가능해 경로를 2개 사용해야 했습니다.