### PR TITLE
ci: problem-matcher 적용

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,12 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm --filter='@jiphyeonjeon-42/contracts' build
 
-      - name: check types
-        run: pnpm -r --no-bail check
+      - if: always()
+        name: check types (backend)
+        working-directory: backend
+        run: pnpm check
+
+      - if: always()
+        name: check types (contracts)
+        working-directory: contracts
+        run: pnpm check


### PR DESCRIPTION
### 개요

![image](https://github.com/jiphyeonjeon-42/backend/assets/54838975/42f97526-eb4d-4d92-9382-c75257652a3b)

https://github.com/jiphyeonjeon-42/backend/actions/runs/5739098638

CI에서 타입 오류를 발견해도 PR에 표시되지 않던 문제 수정

### 원인

[![image](https://github.com/jiphyeonjeon-42/backend/assets/54838975/83f38544-2b45-4561-a5a9-4b66a6d41c02)](https://regex101.com/r/fJ3DAi/3)

https://regex101.com/r/fJ3DAi/3

pnpm -r 로 실행시 정규식이 pnpm 로그까지 함께 포함해 존재하지 않는 파일 경로에 오류가 표시되고 있었음

