### PR TITLE
ci: problem-matcher 적용 (2번째 시도)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ name: Test
 on:
   pull_request:
 
+defaults:
+  run:
+      shell: bash
+
 jobs:
   test:
     name: Test PR
@@ -10,6 +14,8 @@ jobs:
     environment: development
 
     steps:
+      - uses: reviewdog/action-setup@v1
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -40,12 +46,7 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm --filter='@jiphyeonjeon-42/contracts' build
 
-      - if: always()
-        name: check types (backend)
-        working-directory: backend
-        run: pnpm check
-
-      - if: always()
-        name: check types (contracts)
-        working-directory: contracts
-        run: pnpm check
+      - name: check types
+        if: always()
+        run: |
+          pnpm -r --no-bail --parallel run check | sed -r 's|(.*)( check: )(.*)|\1/\3|'


### PR DESCRIPTION

![image](https://github.com/jiphyeonjeon-42/backend/assets/54838975/bb33efe3-1261-49aa-97f7-936f4f7b0569)

#641 을 적용했으나 타입 오류가 `Files changed` 탭에서 보이지 않았는데, `pnpm -r` 실행시 pnpm이 별도의 메시지를 앞에 추가해 생기는 문제였습니다. `sed`로 해당 경로를 잘라내, problem matcher가 읽을 수 있는 형식이 되게 고쳤습니다.