### PR TITLE
feat: kysely 적용

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -48,8 +48,8 @@
   "dependencies": {
     "@jiphyeonjeon-42/contracts": "workspace:*",
     "@slack/web-api": "^6.7.1",
-    "@ts-rest/express": "^3.26.4",
-    "@ts-rest/open-api": "^3.26.4",
+    "@ts-rest/express": "^3.28.0",
+    "@ts-rest/open-api": "^3.28.0",
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "standalone": "npm run build && npm run start",
     "lint": "eslint --fix --ext .js,.ts src",
     "check": "tsc --project ./tsconfig.prod.json --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "schema": ". ./.env && DATABASE_URL=mysql://$RDS_USERNAME:$RDS_PASSWORD@$RDS_HOSTNAME:3306/$RDS_DB_NAME kysely-codegen --dialect=mysql --out-file=src/kysely/generated.ts"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
@@ -40,6 +41,7 @@
     "eslint-plugin-import": "^2.27.5",
     "jest": "^29.5.0",
     "jest-mock-extended": "^3.0.4",
+    "kysely-codegen": "^0.10.1",
     "nodemon": "^3.0.1",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
@@ -61,6 +63,8 @@
     "http-status": "^1.5.0",
     "http-terminator": "^3.2.0",
     "jsonwebtoken": "^8.5.1",
+    "kysely": "^0.26.1",
+    "kysely-paginate": "^0.2.0",
     "morgan": "^1.10.0",
     "mysql2": "^2.3.3",
     "node-schedule": "^2.1.0",

--- a/backend/src/kysely/generated.ts
+++ b/backend/src/kysely/generated.ts
@@ -1,0 +1,286 @@
+import type { ColumnType, SqlBool } from "kysely";
+
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+
+export interface Book {
+  id: Generated<number>;
+  donator: Generated<string | null>;
+  callSign: string;
+  status: number;
+  createdAt: Generated<Date>;
+  infoId: number;
+  updatedAt: Generated<Date>;
+  donatorId: Generated<number | null>;
+}
+
+export interface BookInfo {
+  id: Generated<number>;
+  title: string;
+  author: string;
+  publisher: string;
+  isbn: Generated<string | null>;
+  image: Generated<string | null>;
+  publishedAt: Generated<Date | null>;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  categoryId: number;
+}
+
+export interface Category {
+  id: Generated<number>;
+  name: string;
+}
+
+export interface Lending {
+  id: Generated<number>;
+  lendingLibrarianId: number;
+  lendingCondition: string;
+  returningLibrarianId: Generated<number | null>;
+  returningCondition: Generated<string | null>;
+  returnedAt: Generated<Date | null>;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  bookId: number;
+  userId: number;
+}
+
+export interface Likes {
+  id: Generated<number>;
+  userId: number;
+  bookInfoId: number;
+  isDeleted: Generated<SqlBool>;
+}
+
+export interface Reservation {
+  id: Generated<number>;
+  endAt: Generated<Date | null>;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  status: Generated<number>;
+  bookInfoId: number;
+  bookId: Generated<number | null>;
+  userId: number;
+}
+
+export interface Reviews {
+  id: Generated<number>;
+  userId: number;
+  bookInfoId: number;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  updateUserId: number;
+  isDeleted: Generated<SqlBool>;
+  deleteUserId: Generated<number | null>;
+  content: string;
+  disabled: Generated<SqlBool>;
+  disabledUserId: Generated<number | null>;
+}
+
+export interface SubTag {
+  id: Generated<number>;
+  userId: number;
+  superTagId: number;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  isDeleted: Generated<SqlBool>;
+  updateUserId: number;
+  content: string;
+  isPublic: Generated<number>;
+}
+
+export interface SuperTag {
+  id: Generated<number>;
+  userId: number;
+  bookInfoId: number;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  isDeleted: Generated<SqlBool>;
+  updateUserId: number;
+  content: string;
+}
+
+export interface TypeormMetadata {
+  type: string;
+  database: Generated<string | null>;
+  schema: Generated<string | null>;
+  table: Generated<string | null>;
+  name: Generated<string | null>;
+  value: Generated<string | null>;
+}
+
+export interface User {
+  id: Generated<number>;
+  email: string;
+  password: string;
+  nickname: Generated<string | null>;
+  intraId: Generated<number | null>;
+  slack: Generated<string | null>;
+  penaltyEndDate: Generated<Date>;
+  role: Generated<number>;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+}
+
+export interface UserReservation {
+  reservationId: Generated<number>;
+  endAt: Generated<Date | null>;
+  reservationDate: Generated<Date>;
+  reservedBookInfoId: number;
+  userId: number;
+  title: string | null;
+  author: string | null;
+  image: Generated<string | null>;
+  ranking: Generated<number | null>;
+}
+
+export interface VHistories {
+  id: Generated<number>;
+  returningCondition: Generated<string | null>;
+  login: Generated<string | null>;
+  callSign: string;
+  bookInfoId: Generated<number | null>;
+  title: string | null;
+  image: Generated<string | null>;
+  lendingCondition: string;
+  updatedAt: Generated<Date>;
+  penaltyDays: Generated<number | null>;
+  createdAt: Generated<string | null>;
+  returnedAt: Generated<string | null>;
+  dueDate: Generated<string | null>;
+  lendingLibrarianNickName: Generated<string | null>;
+  returningLibrarianNickname: Generated<string | null>;
+}
+
+export interface VLending {
+  id: Generated<number>;
+  lendingCondition: string;
+  login: Generated<string | null>;
+  bookId: Generated<number | null>;
+  callSign: string | null;
+  title: string | null;
+  image: Generated<string | null>;
+  penaltyDays: Generated<number | null>;
+  createdAt: Generated<string | null>;
+  returnedAt: Generated<string | null>;
+  dueDate: Generated<string | null>;
+}
+
+export interface VLendingForSearchUser {
+  lendingCondition: string;
+  lendDate: Generated<Date>;
+  userId: Generated<number>;
+  bookInfoId: Generated<number | null>;
+  title: string | null;
+  author: string | null;
+  image: Generated<string | null>;
+  duedate: Generated<Date | null>;
+  overDueDay: Generated<number | null>;
+  reservedNum: Generated<number | null>;
+}
+
+export interface VSearchBook {
+  bookId: Generated<number>;
+  donator: Generated<string | null>;
+  callSign: string;
+  status: number;
+  bookInfoId: number;
+  title: string | null;
+  author: string | null;
+  publisher: string | null;
+  isbn: Generated<string | null>;
+  image: Generated<string | null>;
+  categoryId: number | null;
+  category: string | null;
+  publishedAt: Generated<string | null>;
+  isLendable: Generated<number | null>;
+}
+
+export interface VSearchBookByTag {
+  id: Generated<number>;
+  title: string;
+  author: string;
+  isbn: Generated<string | null>;
+  image: Generated<string | null>;
+  publishedAt: Generated<Date | null>;
+  createdAt: Generated<Date>;
+  updatedAt: Generated<Date>;
+  category: string;
+  superTagContent: string;
+  subTagContent: string | null;
+  lendingCnt: Generated<number | null>;
+}
+
+export interface VStock {
+  bookId: Generated<number>;
+  donator: Generated<string | null>;
+  callSign: string;
+  status: number;
+  bookInfoId: number;
+  title: string | null;
+  author: string | null;
+  publisher: string | null;
+  isbn: Generated<string | null>;
+  image: Generated<string | null>;
+  categoryId: number | null;
+  category: string | null;
+  publishedAt: Generated<string | null>;
+  updatedAt: Generated<string | null>;
+}
+
+export interface VTagsSubDefault {
+  bookInfoId: number;
+  title: string;
+  id: Generated<number>;
+  createdAt: Generated<string | null>;
+  login: Generated<string | null>;
+  content: string;
+  superTagId: Generated<number>;
+  superContent: string;
+  isPublic: Generated<number>;
+  isDeleted: Generated<number>;
+  visibility: Generated<string>;
+}
+
+export interface VTagsSuperDefault {
+  content: Generated<string>;
+  count: Generated<number | null>;
+  type: Generated<string>;
+  createdAt: Generated<string | null>;
+}
+
+export interface VUserLending {
+  lendingCondition: string;
+  userId: number;
+  bookInfoId: Generated<number | null>;
+  title: string | null;
+  image: Generated<string | null>;
+  lendDate: Generated<string | null>;
+  duedate: Generated<string | null>;
+  overDueDay: Generated<number | null>;
+}
+
+export interface DB {
+  book: Book;
+  book_info: BookInfo;
+  category: Category;
+  lending: Lending;
+  likes: Likes;
+  reservation: Reservation;
+  reviews: Reviews;
+  sub_tag: SubTag;
+  super_tag: SuperTag;
+  typeorm_metadata: TypeormMetadata;
+  user: User;
+  user_reservation: UserReservation;
+  v_histories: VHistories;
+  v_lending: VLending;
+  v_lending_for_search_user: VLendingForSearchUser;
+  v_search_book: VSearchBook;
+  v_search_book_by_tag: VSearchBookByTag;
+  v_stock: VStock;
+  v_tags_sub_default: VTagsSubDefault;
+  v_tags_super_default: VTagsSuperDefault;
+  v_user_lending: VUserLending;
+}

--- a/backend/src/kysely/mod.ts
+++ b/backend/src/kysely/mod.ts
@@ -1,0 +1,24 @@
+import { Kysely, MysqlDialect } from 'kysely';
+import { createPool } from 'mysql2';
+import type { DB } from './generated.ts';
+import { connectOption } from '~/config/index.ts';
+
+const { database, host, password, username: user } = connectOption;
+
+const dialect = new MysqlDialect({
+  pool: createPool({
+    port: 3306,
+    connectionLimit: 10,
+    host,
+    database,
+    user,
+    password,
+  }),
+});
+
+export const db = new Kysely<DB>({
+  dialect,
+  log: event => console.log('kysely:', event.query.sql, event.query.parameters),
+});
+
+export type Database = typeof db;

--- a/backend/src/kysely/shared.ts
+++ b/backend/src/kysely/shared.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/** 반환값이 조건을 만족하지 않으면 오류 throw */
+const throwIf = <T>(value: T, ok: (v: T) => boolean) => {
+  if (ok(value)) {
+    return value;
+  }
+  throw new Error(`값이 예상과 달리 ${value}입니다`);
+};
+
+export type Visibility = 'public' | 'private' | 'all'
+const roles = ['user', 'cadet', 'librarian', 'staff'] as const;
+export type Role = typeof roles[number]
+
+const fromEnum = (role: number): Role =>
+  throwIf(roles[role], (v) => v === undefined);
+
+export const toRole = (role: Role): number =>
+  throwIf(roles.indexOf(role), (v) => v === -1);
+
+export const roleSchema = z.number().int().min(0).max(3)
+  .transform(fromEnum);

--- a/backend/src/kysely/sqlDates.ts
+++ b/backend/src/kysely/sqlDates.ts
@@ -1,0 +1,62 @@
+import { sql, type Expression, type RawBuilder } from 'kysely';
+
+/**
+ * 현재 시각을 반환합니다.
+ *
+ * @see {@link https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_now | NOW}
+ */
+export const dateNow = () => sql<Date>`NOW()`;
+
+/**
+ * 주어진 DATETIME을 YYYY-MM-DD 형식 문자열로 변환합니다.
+ *
+ * @todo(@scarf005): 임의의 날짜 형식을 타입 안전하게 사용
+ */
+export function dateFormat(
+  expr: Expression<Date>,
+  format: '%Y-%m-%d',
+): RawBuilder<string>;
+
+export function dateFormat(
+  expr: Expression<Date | null>,
+  format: '%Y-%m-%d',
+): RawBuilder<string | null>;
+
+export function dateFormat(expr: Expression<Date | null>, format: '%Y-%m-%d') {
+  return sql<string | null>`DATE_FORMAT(${expr}, ${format})`;
+}
+/**
+ * 주어진 DATETIME에 주어진 일 수를 더합니다.
+ *
+ * @see {@link https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-add | DATE_ADD}
+ */
+export function dateAddDays(
+  expr: Expression<Date>,
+  days: number,
+): RawBuilder<Date>;
+
+export function dateAddDays(expr: Expression<Date | null>, days: number) {
+  return sql<Date | null>`DATE_ADD(${expr}, INTERVAL ${days} DAY)`;
+}
+
+/**
+ * {@link left} - {@link right}일 수를 반환합니다.
+ *
+ * @see {@link https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_datediff | DATEDIFF}
+ */
+export function dateDiff(
+  left: Expression<Date>,
+  right: Expression<Date>,
+): RawBuilder<number>;
+
+export function dateDiff(
+  left: Expression<Date | null>,
+  right: Expression<Date | null>,
+): RawBuilder<number | null>;
+
+export function dateDiff(
+  left: Expression<Date | null>,
+  right: Expression<Date | null>,
+) {
+  return sql`DATEDIFF(${left}, ${right})`;
+}

--- a/backend/src/v2/reviews/repository.ts
+++ b/backend/src/v2/reviews/repository.ts
@@ -1,36 +1,122 @@
-import jipDataSource from '~/app-data-source';
-import { BookInfo, Reviews } from '~/entity/entities';
+import { match } from 'ts-pattern';
+import { db } from '~/kysely/mod.ts';
+import { executeWithOffsetPagination } from 'kysely-paginate';
+import { Visibility } from '~/kysely/shared.js';
+import { SqlBool } from 'kysely';
 
-export const reviewsRepo = jipDataSource.getRepository(Reviews);
-export const bookInfoRepo = jipDataSource.getRepository(BookInfo);
+export const bookInfoExistsById = (id: number) =>
+  db.selectFrom('book_info').where('id', '=', id).executeTakeFirst();
 
-type ToggleReviewArgs = {
+export const getReviewById = (id: number) =>
+  db
+    .selectFrom('reviews')
+    .where('id', '=', id)
+    .select(['userId', 'isDeleted', 'disabled', 'disabledUserId'])
+    .executeTakeFirst();
+
+type SearchOption = {
+  query: string;
+  page: number;
+  perPage: number;
+  visibility: Visibility;
+  sort: 'asc' | 'desc';
+};
+
+const queryReviews = () =>
+  db
+    .selectFrom('reviews')
+    .leftJoin('user', 'user.id', 'reviews.userId')
+    .leftJoin('book_info', 'book_info.id', 'reviews.bookInfoId')
+    .select([
+      'id',
+      'userId',
+      'bookInfoId',
+      'content',
+      'createdAt',
+      'book_info.title',
+      'user.nickname',
+      'user.intraId',
+    ]);
+
+export const searchReviews = ({
+  query,
+  sort,
+  visibility,
+  page,
+  perPage,
+}: SearchOption) => {
+  const searchQuery = queryReviews()
+    .where('content', 'like', `%${query}%`)
+    .orderBy('updatedAt', sort);
+
+  const withVisibility = match(visibility)
+    .with('public', () => searchQuery.where('disabled', '=', false))
+    .with('private', () => searchQuery.where('disabled', '=', true))
+    .with('all', () => searchQuery)
+    .exhaustive();
+
+  return executeWithOffsetPagination(withVisibility, { page, perPage });
+};
+
+type InsertOption = {
+  userId: number;
+  bookInfoId: number;
+  content: string;
+};
+export const insertReview = ({ userId, bookInfoId, content }: InsertOption) =>
+  db
+    .insertInto('reviews')
+    .values({
+      userId,
+      updateUserId: userId,
+      bookInfoId,
+      content,
+      disabled: false,
+      isDeleted: false,
+      createdAt: new Date(),
+    })
+    .executeTakeFirst();
+
+type DeleteOption = {
+  reviewsId: number;
+  deleteUserId: number;
+};
+export const deleteReviewById = ({ reviewsId, deleteUserId }: DeleteOption) =>
+  db
+    .updateTable('reviews')
+    .where('id', '=', reviewsId)
+    .set({ deleteUserId, isDeleted: true })
+    .executeTakeFirst();
+
+type ToggleVisibilityOption = {
   reviewsId: number;
   userId: number;
-  disabled: boolean;
+  disabled: SqlBool;
 };
-export const toggleReviewVisibilityById = async ({
+export const toggleVisibilityById = ({
   reviewsId,
   userId,
   disabled,
-}: ToggleReviewArgs) =>
-  reviewsRepo.update(reviewsId, {
-    disabled: !disabled,
-    disabledUserId: disabled ? null : userId,
-  });
+}: ToggleVisibilityOption) =>
+  db
+    .updateTable('reviews')
+    .where('id', '=', reviewsId)
+    .set({ disabled: !disabled, disabledUserId: userId })
+    .executeTakeFirst();
 
-export const findDisabledReviewById = ({
-  id,
-}: {
-  id: number;
-}): Promise<Pick<Reviews, 'disabled' | 'disabledUserId'> | null> =>
-  reviewsRepo.findOne({
-    select: { disabled: true, disabledUserId: true },
-    where: { id },
-  });
-type RemoveReviewById = { reviewsId: number; deleteUserId: number };
-export const removeReviewById = async ({
+type UpdateOption = {
+  reviewsId: number;
+  userId: number;
+  content: string;
+};
+
+export const updateReviewById = ({
   reviewsId,
-  deleteUserId,
-}: RemoveReviewById) =>
-  reviewsRepo.update(reviewsId, { deleteUserId, isDeleted: true });
+  userId,
+  content,
+}: UpdateOption) =>
+  db
+    .updateTable('reviews')
+    .where('id', '=', reviewsId)
+    .set({ content, updateUserId: userId })
+    .executeTakeFirst();

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -11,7 +11,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@anatine/zod-openapi": "^2.0.1",
+    "@anatine/zod-openapi": "^2.1.0",
     "openapi3-ts": "^4.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,11 @@
 {
   "dependencies": {
-    "zod": "^3.21.4",
-    "@ts-rest/core": "^3.26.4"
+    "zod": "^3.22.2",
+    "@ts-rest/core": "^3.28.0"
   },
 	"devDependencies": {
     "typescript": "5.1.6",
     "@types/node": "18.16.1",
 		"rome": "^12.1.3"
-	},
-	"pnpm": {
-		"patchedDependencies": {
-			"@ts-rest/express@3.26.4": "patches/@ts-rest__express@3.26.4.patch"
-		}
 	}
 }

--- a/patches/@ts-rest__express@3.26.4.patch
+++ b/patches/@ts-rest__express@3.26.4.patch
@@ -1,9 +1,0 @@
-diff --git a/src/index.d.ts b/src/index.d.ts
-index 07d95e53eef6937cbb8adb9b1ce629829177e540..1780010c0b3b19605970fe7ad741ca5b9185d58d 100644
---- a/src/index.d.ts
-+++ b/src/index.d.ts
-@@ -1,3 +1,3 @@
- export * from './lib/ts-rest-express';
--export { TsRestRequest, TsRestRequestHandler } from './lib/types';
-+export * from './lib/types';
- export { RequestValidationError } from './lib/request-validation-error';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,21 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-patchedDependencies:
-  '@ts-rest/express@3.26.4':
-    hash: t3ptl42x2xvwgxx73mnwrx7r44
-    path: patches/@ts-rest__express@3.26.4.patch
-
 importers:
 
   .:
     dependencies:
       '@ts-rest/core':
-        specifier: ^3.26.4
-        version: 3.26.4(zod@3.21.4)
+        specifier: ^3.28.0
+        version: 3.28.0(zod@3.22.2)
       zod:
-        specifier: ^3.21.4
-        version: 3.21.4
+        specifier: ^3.22.2
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 18.16.1
@@ -39,11 +34,11 @@ importers:
         specifier: ^6.7.1
         version: 6.7.1
       '@ts-rest/express':
-        specifier: ^3.26.4
-        version: 3.26.4(patch_hash=t3ptl42x2xvwgxx73mnwrx7r44)(@ts-rest/core@3.26.4)(express@4.17.2)(zod@3.21.4)
+        specifier: ^3.28.0
+        version: 3.28.0(@ts-rest/core@3.28.0)(express@4.17.2)(zod@3.22.2)
       '@ts-rest/open-api':
-        specifier: ^3.26.4
-        version: 3.26.4(@ts-rest/core@3.26.4)(zod@3.21.4)
+        specifier: ^3.28.0
+        version: 3.28.0(@ts-rest/core@3.28.0)(zod@3.22.2)
       axios:
         specifier: ^0.27.2
         version: 0.27.2
@@ -77,6 +72,12 @@ importers:
       jsonwebtoken:
         specifier: ^8.5.1
         version: 8.5.1
+      kysely:
+        specifier: ^0.26.1
+        version: 0.26.1
+      kysely-paginate:
+        specifier: ^0.2.0
+        version: 0.2.0(kysely@0.26.1)
       morgan:
         specifier: ^1.10.0
         version: 1.10.0
@@ -195,6 +196,9 @@ importers:
       jest-mock-extended:
         specifier: ^3.0.4
         version: 3.0.4(jest@29.5.0)(typescript@5.1.6)
+      kysely-codegen:
+        specifier: ^0.10.1
+        version: 0.10.1(kysely@0.26.1)(mysql2@2.3.3)(pg@8.11.1)
       nodemon:
         specifier: ^3.0.1
         version: 3.0.1
@@ -211,8 +215,8 @@ importers:
   contracts:
     dependencies:
       '@anatine/zod-openapi':
-        specifier: ^2.0.1
-        version: 2.0.1(openapi3-ts@4.1.2)(zod@3.21.4)
+        specifier: ^2.1.0
+        version: 2.1.0(openapi3-ts@4.1.2)(zod@3.22.2)
       openapi3-ts:
         specifier: ^4.1.2
         version: 4.1.2
@@ -248,7 +252,7 @@ packages:
       '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
-  /@anatine/zod-openapi@1.14.2(openapi3-ts@2.0.2)(zod@3.21.4):
+  /@anatine/zod-openapi@1.14.2(openapi3-ts@2.0.2)(zod@3.22.2):
     resolution: {integrity: sha512-q0qHfnuNYVKu0Swrnnvfj9971AEyW7c8v9jCOZGCl5ZbyGMNG4RPyJkRcMi/JC8CRfdOe0IDfNm1nNsi2avprg==}
     peerDependencies:
       openapi3-ts: ^2.0.0 || ^3.0.0
@@ -256,18 +260,18 @@ packages:
     dependencies:
       openapi3-ts: 2.0.2
       ts-deepmerge: 6.2.0
-      zod: 3.21.4
+      zod: 3.22.2
     dev: false
 
-  /@anatine/zod-openapi@2.0.1(openapi3-ts@4.1.2)(zod@3.21.4):
-    resolution: {integrity: sha512-ks13oMq3wKFobQ6W+C9h893b2kYAff4Giqwmr5gxgP1HyoBhM4Iub1Z/Q3x5EsAfqfTi8qEOBuqTf0Tnv10D2w==}
+  /@anatine/zod-openapi@2.1.0(openapi3-ts@4.1.2)(zod@3.22.2):
+    resolution: {integrity: sha512-SQML15KBRP8FyV7djAEZiv3iCA0ve++WZ6wW3OBqrABwxszoOcXbtQs27eM13I7FN8GD/9NBSmoh1pgI+fM75A==}
     peerDependencies:
       openapi3-ts: ^4.1.2
       zod: ^3.20.0
     dependencies:
       openapi3-ts: 4.1.2
       ts-deepmerge: 6.2.0
-      zod: 3.21.4
+      zod: 3.22.2
     dev: false
 
   /@apidevtools/json-schema-ref-parser@9.1.2:
@@ -1406,43 +1410,42 @@ packages:
     dev: true
     optional: true
 
-  /@ts-rest/core@3.26.4(zod@3.21.4):
-    resolution: {integrity: sha512-mgDkGKnE+N67dtD2xkHh9vstlUI++p1INj93hFhQYsT9Awx+oUBY2GwzU4fSaJybKFIvQEC9NEMMWx1/E+7kiQ==}
+  /@ts-rest/core@3.28.0(zod@3.22.2):
+    resolution: {integrity: sha512-m0Wn2DgO3O57dsGT5fqxvF/WNFPx/8/dxbqLMV9TYXwLBgaJG4vDgR7qXVIYss/c5vlHTQ0oB9X+PwxhI3ksMg==}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.21.0
     peerDependenciesMeta:
       zod:
         optional: true
     dependencies:
-      zod: 3.21.4
+      zod: 3.22.2
     dev: false
 
-  /@ts-rest/express@3.26.4(patch_hash=t3ptl42x2xvwgxx73mnwrx7r44)(@ts-rest/core@3.26.4)(express@4.17.2)(zod@3.21.4):
-    resolution: {integrity: sha512-F9Xv25E/B3y4st1dWg4xfQO7i3hF3sNzgytJ7Uyh/s9AT+LM4Qgyj3g5xKK4gvSV6hG2aCzoQzuI7NkCN2wYIQ==}
+  /@ts-rest/express@3.28.0(@ts-rest/core@3.28.0)(express@4.17.2)(zod@3.22.2):
+    resolution: {integrity: sha512-kkFdgBCtSDGIRcnh+uJGK5BMiYo/bHMH0/zVhAA4T3Wb6PPixf80GtsT9KiOOciVrG4JtLWQbsdTh69KxjPe5g==}
     peerDependencies:
-      '@ts-rest/core': 3.26.4
+      '@ts-rest/core': 3.28.0
       express: ^4.0.0
-      zod: ^3.0.0
+      zod: ^3.21.0
     peerDependenciesMeta:
       zod:
         optional: true
     dependencies:
-      '@ts-rest/core': 3.26.4(zod@3.21.4)
+      '@ts-rest/core': 3.28.0(zod@3.22.2)
       express: 4.17.2
-      zod: 3.21.4
+      zod: 3.22.2
     dev: false
-    patched: true
 
-  /@ts-rest/open-api@3.26.4(@ts-rest/core@3.26.4)(zod@3.21.4):
-    resolution: {integrity: sha512-RopH8p9APBVPAap6ZW9uCvfOGecSc4jud2sug9ERZvqd6KTDR8/QmMe0UHplFwdGEs+QOCtY0L2PWnHMIQ6UVg==}
+  /@ts-rest/open-api@3.28.0(@ts-rest/core@3.28.0)(zod@3.22.2):
+    resolution: {integrity: sha512-9EG1mWxzcTriWAQGLNLXvpRT5VLKIQGPcBfTndRDsHUQe9jor+GtjEP8ttuoTfo3GlhkND9V6Qrikda1/kM0tg==}
     peerDependencies:
-      '@ts-rest/core': 3.26.4
-      zod: ^3.0.0
+      '@ts-rest/core': 3.28.0
+      zod: ^3.21.0
     dependencies:
-      '@anatine/zod-openapi': 1.14.2(openapi3-ts@2.0.2)(zod@3.21.4)
-      '@ts-rest/core': 3.26.4(zod@3.21.4)
+      '@anatine/zod-openapi': 1.14.2(openapi3-ts@2.0.2)(zod@3.22.2)
+      '@ts-rest/core': 3.28.0(zod@3.22.2)
       openapi3-ts: 2.0.2
-      zod: 3.21.4
+      zod: 3.22.2
     dev: false
 
   /@types/babel__core@7.20.1:
@@ -2828,6 +2831,11 @@ packages:
     resolution: {integrity: sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==}
     engines: {node: '>=12'}
     dev: false
+
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
+    dev: true
 
   /dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
@@ -4753,6 +4761,44 @@ packages:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
     dev: false
 
+  /kysely-codegen@0.10.1(kysely@0.26.1)(mysql2@2.3.3)(pg@8.11.1):
+    resolution: {integrity: sha512-8Bslh952gN5gtucRv4jTZDFD18RBioS6M50zHfe5kwb5iSyEAunU4ZYMdHzkHraa4zxjg5/183XlOryBCXLRIw==}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '>=7.6.2'
+      kysely: '>=0.19.12'
+      mysql2: ^2.3.3 || ^3.0.0
+      pg: ^8.8.0
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+    dependencies:
+      chalk: 4.1.2
+      dotenv: 16.3.1
+      kysely: 0.26.1
+      micromatch: 4.0.5
+      minimist: 1.2.8
+      mysql2: 2.3.3
+      pg: 8.11.1
+    dev: true
+
+  /kysely-paginate@0.2.0(kysely@0.26.1):
+    resolution: {integrity: sha512-LsnhnfmXJH+bjFVGy67dXkg21QYBFffLFI+R1FDr/wSyq3yMXGKaxwlbl9r7kXe1QZPXLSIB3oT+nmC1waDTqg==}
+    engines: {node: '>= 16.14.0'}
+    peerDependencies:
+      kysely: ^0.24.2
+    dependencies:
+      kysely: 0.26.1
+    dev: false
+
+  /kysely@0.26.1:
+    resolution: {integrity: sha512-FVRomkdZofBu3O8SiwAOXrwbhPZZr8mBN5ZeUWyprH29jzvy6Inzqbd0IMmGxpd4rcOCL9HyyBNWBa8FBqDAdg==}
+    engines: {node: '>=14.0.0'}
+
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -5399,7 +5445,7 @@ packages:
       commander: 10.0.1
       js-yaml: 4.1.0
       undici: 5.22.1
-      zod: 3.21.4
+      zod: 3.22.2
     dev: true
 
   /openapi-types@12.1.3:
@@ -7355,8 +7401,8 @@ packages:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
     dev: true
 
-  /zod@3.21.4:
-    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+  /zod@3.22.2:
+    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
 
   '@github.com/scarf005/vitest/releases/download/v0.33.0-2023-07-30/vite-node-0.33.0.tgz(@types/node@18.16.1)':
     resolution: {tarball: https://github.com/scarf005/vitest/releases/download/v0.33.0-2023-07-30/vite-node-0.33.0.tgz}


### PR DESCRIPTION
### 개요

![image](https://github.com/jiphyeonjeon-42/backend/assets/54838975/6098fa3f-aa8e-4814-b25e-6673a1beeb8f)

https://github.com/orgs/jiphyeonjeon-42/discussions/9#discussioncomment-6677350

- 선행 PR: #665 

### 작업 사항

- [kysely](https://kysely.dev/) 패키지 추가
	- [kysely-paginate](https://github.com/charlie-hadden/kysely-paginate): cursor와 offset 기반 페이지네이션 지원
	- [kysely-codegen](https://github.com/RobinBlomberg/kysely-codegen): [typeorm-model-generator](https://www.npmjs.com/package/typeorm-model-generator)처럼 DB에서 엔티티 타입 생성

### 변경점

- `ts-rest` 버전 업데이트
- `v2/reviews`에서 kysely 사용

### 목적

raw query를 타입 안전하게 변경
