### PR TITLE
feat: 42 API로부터 사용자의 과제 정보 받아오는 기능 구현

### DIFF
--- a/backend/src/v1/DTO/cursus.model.ts
+++ b/backend/src/v1/DTO/cursus.model.ts
@@ -1,0 +1,57 @@
+export type RawProject = {
+  id: number;
+  occurrence: number;
+  final_mark: number;
+  status: string;
+  'validated?': boolean;
+  current_team_id: number;
+  project: {
+    id: number;
+    name: string;
+    slug: string;
+    parent_id: number;
+  };
+  cursus_ids: number[];
+  marked_at: string;
+  marked: boolean;
+  retriable_at: string;
+  created_at: string;
+  updated_at: string;
+  user: {
+    id: number;
+    email: string;
+    login: string;
+    first_name: string;
+    last_name: string;
+    usual_full_name: string;
+    usual_first_name: string;
+    url: string;
+    phone: string;
+    displayname: string;
+    kind: string;
+    image: object;
+    'staff?': boolean;
+    correction_point: number;
+    pool_month: string;
+    pool_year: string;
+    location: string;
+    wallet: number;
+    anonymize_date: string;
+    data_erasure_date: string;
+    created_at: string;
+    updated_at: string;
+    alumnized_at: string;
+    'alumni?': boolean;
+    'active?': boolean;
+  };
+  teams: object[];
+}
+
+export type Project = {
+  id: RawProject['id'];
+  status: RawProject['status'];
+  validated: RawProject['validated?'];
+  project: RawProject['project'];
+  cursus_ids: RawProject['cursus_ids'];
+  marked: RawProject['marked'];
+}

--- a/backend/src/v1/DTO/cursus.model.ts
+++ b/backend/src/v1/DTO/cursus.model.ts
@@ -54,4 +54,5 @@ export type Project = {
   project: RawProject['project'];
   cursus_ids: RawProject['cursus_ids'];
   marked: RawProject['marked'];
+  marked_at: RawProject['marked_at'];
 }

--- a/backend/src/v1/books/books.controller.ts
+++ b/backend/src/v1/books/books.controller.ts
@@ -471,9 +471,10 @@ export const recommandBook = async (
   req: Request,
   res: Response,
 ) => {
+  const { nickname: login } = req.user as any;
   const accessToken: string = await BooksService.getAccessToken();
   // TODO => accessToken이 없을 경우를 분리해야 함
-  const userId: string = await BooksService.getUserIdFrom42API(accessToken);
+  const userId: string = await BooksService.getUserIdFrom42API(accessToken, login);
   const userProject = await BooksService.getUserProjectFrom42API(accessToken, userId);
   res.status(status.OK).send();
 };

--- a/backend/src/v1/books/books.controller.ts
+++ b/backend/src/v1/books/books.controller.ts
@@ -471,10 +471,9 @@ export const recommandBook = async (
   req: Request,
   res: Response,
 ) => {
-  // TODO => 사용자의 과제 정보 가져오는 서비스 함수 호출하게 분리
   const accessToken: string = await BooksService.getAccessToken();
+  // TODO => accessToken이 없을 경우를 분리해야 함
   const userId: string = await BooksService.getUserIdFrom42API(accessToken);
   const userProject = await BooksService.getUserProjectFrom42API(accessToken, userId);
-  console.log(userId);
   res.status(status.OK).send();
 };

--- a/backend/src/v1/books/books.controller.ts
+++ b/backend/src/v1/books/books.controller.ts
@@ -9,7 +9,7 @@ import ErrorResponse from '~/v1/utils/error/errorResponse';
 import isNullish from '~/v1/utils/isNullish';
 import * as parseCheck from '~/v1/utils/parseCheck';
 import { fetchApi } from '@ts-rest/core';
-import { verify } from 'jsonwebtoken';
+import { JwtPayload, verify } from 'jsonwebtoken';
 import { jwtOption } from '~/config';
 import axios from 'axios';
 import * as BooksService from './books.service';
@@ -471,31 +471,10 @@ export const recommandBook = async (
   req: Request,
   res: Response,
 ) => {
-  const tokenURL = 'https://api.intra.42.fr/oauth/token';
-  const queryString = `grant_type=client_credentials&client_id=${process.env.CLIENT_ID}&client_secret=${process.env.CLIENT_SECRET}&redirect_uri=${process.env.REDIRECT_URI}`;
-  const path = 'https://api.intra.42.fr/v2/cursus';
-  let accessToken;
-  await axios(tokenURL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    data: queryString,
-  }).then((response) => {
-    accessToken = response.data.access_token;
-  }).catch((error) => {
-    console.log(error);
-  });
-
-  await axios(path, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  }).then((response) => {
-    console.log(response.data);
-  }).catch((error) => {
-    console.log(error);
-  });
+  // TODO => 사용자의 과제 정보 가져오는 서비스 함수 호출하게 분리
+  const accessToken: string = await BooksService.getAccessToken();
+  const userId: string = await BooksService.getUserIdFrom42API(accessToken);
+  const userProject = await BooksService.getUserProjectFrom42API(accessToken, userId);
+  console.log(userId);
   res.status(status.OK).send();
 };

--- a/backend/src/v1/books/books.service.ts
+++ b/backend/src/v1/books/books.service.ts
@@ -494,6 +494,7 @@ export const getUserProjectFrom42API = async (
         project: data.project,
         cursus_ids: data.cursus_ids,
         marked: data.marked,
+        marked_at: data.marked_at,
       });
     });
   }).catch((error) => {

--- a/backend/src/v1/books/books.service.ts
+++ b/backend/src/v1/books/books.service.ts
@@ -453,10 +453,10 @@ export const getAccessToken = async (): Promise<string> => {
 
 export const getUserIdFrom42API = async (
   accessToken: string,
+  login: string,
 ): Promise<string> => {
   const userURL = 'https://api.intra.42.fr/v2/users';
-  // TODO => login 이름 변수로 받아오게 해야함
-  const queryString = 'filter[login]=yena';
+  const queryString = `filter[login]=${login}`;
   let userId: string = '';
   await axios(`${userURL}?${queryString}`, {
     method: 'GET',

--- a/backend/src/v1/books/books.service.ts
+++ b/backend/src/v1/books/books.service.ts
@@ -15,6 +15,7 @@ import {
   categoryIds, UpdateBookDonator,
 } from './books.type';
 import { categoryWithBookCount } from '../DTO/common.interface';
+import { Project, RawProject } from '../DTO/cursus.model';
 
 const getInfoInNationalLibrary = async (isbn: string) => {
   let book;
@@ -454,6 +455,7 @@ export const getUserIdFrom42API = async (
   accessToken: string,
 ): Promise<string> => {
   const userURL = 'https://api.intra.42.fr/v2/users';
+  // TODO => login 이름 변수로 받아오게 해야함
   const queryString = 'filter[login]=yena';
   let userId: string = '';
   await axios(`${userURL}?${queryString}`, {
@@ -470,8 +472,32 @@ export const getUserIdFrom42API = async (
   return userId;
 };
 
-export const getUserProject = async (
+export const getUserProjectFrom42API = async (
   accessToken: string,
   userId: string,
-): Promise<any> => {
+): Promise<Project[]> => {
+  const projectURL = `https://api.intra.42.fr/v2/users/${userId}/projects_users`;
+  const userProject: Array<Project> = [];
+  await axios(projectURL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  }).then((response) => {
+    const rawData: RawProject[] = response.data;
+    rawData.forEach((data: RawProject) => {
+      userProject.push({
+        id: data.id,
+        status: data.status,
+        validated: data['validated?'],
+        project: data.project,
+        cursus_ids: data.cursus_ids,
+        marked: data.marked,
+      });
+    });
+  }).catch((error) => {
+    console.log(error.message);
+  });
+  return userProject;
 };

--- a/backend/src/v1/routes/books.routes.ts
+++ b/backend/src/v1/routes/books.routes.ts
@@ -114,7 +114,7 @@ router
    *                description: error decription
    *                example: { errorCode: 500 }
    */
-  .get('/recommand', recommandBook);
+  .get('/recommand', authValidate(roleSet.all), recommandBook);
 
 router
   /**

--- a/backend/src/v1/routes/books.routes.ts
+++ b/backend/src/v1/routes/books.routes.ts
@@ -13,6 +13,7 @@ import {
   getLikeInfo,
   updateBookInfo,
   updateBookDonator,
+  recommandBook,
 } from '~/v1/books/books.controller';
 import authValidate from '~/v1/auth/auth.validate';
 import authValidateDefaultNullUser from '~/v1/auth/auth.validateDefaultNullUser';
@@ -20,6 +21,100 @@ import { roleSet } from '~/v1/auth/auth.type';
 
 export const path = '/books';
 export const router = Router();
+
+router
+  /**
+   * @openapi
+   * /api/books/recommand:
+   *    get:
+   *      summary: 서클 별 추천 도서를 가져온다
+   *      description: 사용자가 속한 서클의 추천 도서를 가져온다
+   *      tags:
+   *      - books
+   *      parameters:
+   *      - name: limit
+   *        in: query
+   *        description: 가져올 추천 도서의 개수
+   *        schema:
+   *          type: integer
+   *        example: 4
+   *      - name: type
+   *        in: query
+   *        description: 이너 서클과 아우터 서클을 구분한다
+   *        schema:
+   *          type: string
+   *          enum: [inner, outer]
+   *      - name: circleOrSubject
+   *        in: query
+   *        description: 서클 또는 과제 명을 받아온다.
+   *        schema:
+   *          type: string
+   *        example: Libft
+   *      responses:
+   *        '200':
+   *          description: 서클 별 추천 도서의 정보를 가져온다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    description: 추천 도서들의 목록
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        id:
+   *                          description: DB 상의 book_info.id
+   *                          type: integer
+   *                          example: 42
+   *                        title:
+   *                          description: 도서 제목
+   *                          type: string
+   *                          example: "시작하세요! 도커/쿠버네티스"
+   *                        author:
+   *                          description: 저자
+   *                          type: string
+   *                          example: 용찬호
+   *                        publisher:
+   *                          description: 출판사
+   *                          type: string
+   *                          example: 위키북스
+   *                        image:
+   *                          description: 표지 사진
+   *                          type: string
+   *                          example: https://image.kyobobook.co.kr/images/book/xlarge/394/x9791195982394.jpg
+   *                        publishedAt:
+   *                          description: 출판일자
+   *                          type: string
+   *                          format: date
+   *                          example: 2020-01-31
+   *                        subjects:
+   *                          description: 도서와 관련된 과제들
+   *                          type: array
+   *                          example: ["Inception", "Inception-of-Things"]
+   *                  meta:
+   *                    description: 드롭다운에서 선택할 수 있는 서클과 과제 정보
+   *                    type: array
+   *                    example: ["0서클 | Libft", "1서클 | ft_printf", ..., "Outer | ft_ping"]
+   *        '400':
+   *          description: x 서클에서 y 과제의 추천 도서를 가져오려고 했는데, x 서클에 y 과제가 없다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: json
+   *                description: error decription
+   *                example: { errorCode: 400 }
+   *        '500':
+   *          description: 서버 오류
+   *          content:
+   *           application/json:
+   *              schema:
+   *                type: json
+   *                description: error decription
+   *                example: { errorCode: 500 }
+   */
+  .get('/recommand', recommandBook);
 
 router
   /**
@@ -1102,97 +1197,3 @@ router
  */
   .patch('/update', authValidate(roleSet.librarian), updateBookInfo)
   .patch('/donator', authValidate(roleSet.librarian), updateBookDonator);
-
-  router
-  /**
-   * @openapi
-   * /api/books/recommand:
-   *    get:
-   *      summary: 서클 별 추천 도서를 가져온다
-   *      description: 사용자가 속한 서클의 추천 도서를 가져온다
-   *      tags:
-   *      - books
-   *      parameters:
-   *      - name: limit
-   *        in: query
-   *        description: 가져올 추천 도서의 개수
-   *        schema:
-   *          type: integer
-   *        example: 4
-   *      - name: type
-   *        in: query
-   *        description: 이너 서클과 아우터 서클을 구분한다
-   *        schema:
-   *          type: string
-   *          enum: [inner, outer]
-   *      - name: circleOrSubject
-   *        in: query
-   *        description: 서클 또는 과제 명을 받아온다.
-   *        schema:
-   *          type: string
-   *        example: Libft
-   *      responses:
-   *        '200':
-   *          description: 서클 별 추천 도서의 정보를 가져온다.
-   *          content:
-   *            application/json:
-   *              schema:
-   *                type: object
-   *                properties:
-   *                  items:
-   *                    description: 추천 도서들의 목록
-   *                    type: array
-   *                    items:
-   *                      type: object
-   *                      properties:
-   *                        id:
-   *                          description: DB 상의 book_info.id
-   *                          type: integer
-   *                          example: 42
-   *                        title:
-   *                          description: 도서 제목
-   *                          type: string
-   *                          example: "시작하세요! 도커/쿠버네티스"
-   *                        author:
-   *                          description: 저자
-   *                          type: string
-   *                          example: 용찬호
-   *                        publisher:
-   *                          description: 출판사
-   *                          type: string
-   *                          example: 위키북스
-   *                        image:
-   *                          description: 표지 사진
-   *                          type: string
-   *                          example: https://image.kyobobook.co.kr/images/book/xlarge/394/x9791195982394.jpg
-   *                        publishedAt:
-   *                          description: 출판일자
-   *                          type: string
-   *                          format: date
-   *                          example: 2020-01-31
-   *                        subjects:
-   *                          description: 도서와 관련된 과제들
-   *                          type: array
-   *                          example: ["Inception", "Inception-of-Things"]
-   *                  meta:
-   *                    description: 드롭다운에서 선택할 수 있는 서클과 과제 정보
-   *                    type: array
-   *                    example: ["0서클 | Libft", "1서클 | ft_printf", ..., "Outer | ft_ping"]
-   *        '400':
-   *          description: x 서클에서 y 과제의 추천 도서를 가져오려고 했는데, x 서클에 y 과제가 없다.
-   *          content:
-   *            application/json:
-   *              schema:
-   *                type: json
-   *                description: error decription
-   *                example: { errorCode: 400 }
-   *        '500':
-   *          description: 서버 오류
-   *          content:
-   *           application/json:
-   *              schema:
-   *                type: json
-   *                description: error decription
-   *                example: { errorCode: 500 }
-   */
-  .get('/recommand'/* , recommand */);


### PR DESCRIPTION
### 개요
- 도서 추천 컨트롤러 추가
- books.routes.ts에서 도서 추천 라우터 순서 변경
- 도서 추천 컨트롤러 내에서 42 API 통신 테스트

### 비고
- 어차피 access_token 만료 기간 짧은 거 그냥 API 호출 때마다 새로 토큰 받아오면 안 되나?
  - 그러면 너무 느릴까?
