### PR TITLE
feat: 인기 검색어 순위 집계 기능 및 swagger 구현

### DIFF
--- a/backend/src/v1/routes/index.ts
+++ b/backend/src/v1/routes/index.ts
@@ -10,6 +10,7 @@ import * as bookInfoReviews from './bookInfoReviews.routes';
 import * as stock from './stock.routes';
 import * as tags from './tags.routes';
 import * as cursus from './cursus.routes';
+import * as searchKeywords from './search-keywords.routes';
 
 const router = Router();
 
@@ -29,5 +30,6 @@ router.use(bookInfoReviews.path, bookInfoReviews.router);
 router.use(stock.path, stock.router);
 router.use(tags.path, tags.router);
 router.use(cursus.path, cursus.router);
+router.use(searchKeywords.path, searchKeywords.router);
 
 export default router;

--- a/backend/src/v1/routes/search-keywords.routes.ts
+++ b/backend/src/v1/routes/search-keywords.routes.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+import { getPopularSearchKeywords } from '../search-keywords/search-keywords.controller';
+
+export const path = '/search-keywords';
+export const router = Router();
+
+router
+  /**
+   * @openapi
+   * /api/search-keywords/popular:
+   *    get:
+   *      description: 인기 검색어 순위를 10위까지 가져온다. 동순위가 있는 경우 가장 최근에 검색된 검색어 순으로 보여준다.
+   *      tags:
+   *      - search-keywords
+   *      responses:
+   *        '200':
+   *          description: 인기 검색어 10위.
+   *                       rankingChange는 순위가 올랐으면 양수, 떨어졌으면 음수, 그대로면 0 이며, 새롭게 진입한 검색어는 null이다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    type: array
+   *                    example: [
+   *                               { "searchKeyword": 'aws', "rankingChange": 2 },
+   *                               { "searchKeyword": '파이썬', "rankingChange": 0 },
+   *                               { "searchKeyword": '도커', "rankingChange": -2 },
+   *                               { "searchKeyword": 'tcp', "rankingChange": 0 },
+   *                               { "searchKeyword": '스위프트', "rankingChange": 0 },
+   *                               { "searchKeyword": '자바', "rankingChange": 0 },
+   *                               { "searchKeyword": '검색', "rankingChange": 0 },
+   *                               { "searchKeyword": 'http', "rankingChange": null },
+   *                               { "searchKeyword": '리액트', "rankingChange": -1 },
+   *                               { "searchKeyword": 'java', "rankingChange": -1 }
+   *                             ]
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        searchKeyword:
+   *                          description: 검색어
+   *                          type: string
+   *                        rankingChange:
+   *                          description: 순위 등락
+   *                          type: integer
+   */
+  .get('/popular', getPopularSearchKeywords);

--- a/backend/src/v1/search-keywords/search-keywords.controller.ts
+++ b/backend/src/v1/search-keywords/search-keywords.controller.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from 'express';
+import { logger } from '~/logger';
+import * as errorCode from '~/v1/utils/error/errorCode';
+import ErrorResponse from '~/v1/utils/error/errorResponse';
+import * as status from 'http-status';
+import * as SearchKeywordsService from './search-keywords.service';
+import { PopularSearchKeyword } from './search-keywords.type';
+
+export const getPopularSearchKeywords = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<Response | void> => {
+  try {
+    const items: PopularSearchKeyword[] = await SearchKeywordsService.getPopularSearchKeywords();
+    return res.status(status.OK).json({ items });
+  } catch (error: any) {
+    const errorNumber = parseInt(error.message, 10);
+    if (errorNumber >= 300 && errorNumber < 400) {
+      return next(new ErrorResponse(error.message, status.BAD_REQUEST));
+    }
+    if (error.message === 'DB error') {
+      return next(
+        new ErrorResponse(
+          errorCode.QUERY_EXECUTION_FAILED,
+          status.INTERNAL_SERVER_ERROR,
+        ),
+      );
+    }
+    logger.error(error);
+    return next(
+      new ErrorResponse(errorCode.UNKNOWN_ERROR, status.INTERNAL_SERVER_ERROR),
+    );
+  }
+};

--- a/backend/src/v1/search-keywords/search-keywords.service.ts
+++ b/backend/src/v1/search-keywords/search-keywords.service.ts
@@ -1,0 +1,67 @@
+import { executeQuery } from '~/mysql';
+import { PopularSearchKeyword, SearchKeyword } from './search-keywords.type';
+
+const MINIMUN_SEARCH_COUNT = 5;
+const POPULAR_KEYWORDS_LIMIT = 10;
+let lastPopular: string[] = [];
+
+export const getPopularSearchKeywords = async () => {
+  const popularKeywords = await executeQuery(
+    `
+    (
+      SELECT keyword
+      FROM search_logs
+      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
+      WHERE search_logs.timestamp BETWEEN NOW() - INTERVAL 1 DAY AND NOW()
+      GROUP BY search_keywords.keyword
+      HAVING COUNT(search_keywords.keyword) >= ?
+      ORDER BY COUNT(search_keywords.keyword) DESC, MAX(search_logs.timestamp) DESC
+      LIMIT ?
+    )
+    UNION
+    (
+      SELECT keyword
+      FROM search_logs
+      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
+      WHERE search_logs.timestamp BETWEEN NOW() - INTERVAL 1 MONTH AND NOW()
+      GROUP BY search_keywords.keyword
+      HAVING COUNT(search_keywords.keyword) >= ?
+      ORDER BY COUNT(search_keywords.keyword) DESC, MAX(search_logs.timestamp) DESC
+      LIMIT ?
+    )
+    UNION
+    (
+      SELECT keyword
+      FROM search_logs
+      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
+      GROUP BY search_keywords.keyword
+      HAVING COUNT(search_keywords.keyword) >= ?
+      ORDER BY COUNT(search_keywords.keyword) desc, MAX(search_logs.timestamp) desc
+      LIMIT ?
+    )
+    LIMIT ?
+    `,
+    [
+      `${MINIMUN_SEARCH_COUNT}`,
+      POPULAR_KEYWORDS_LIMIT,
+      `${MINIMUN_SEARCH_COUNT}`,
+      POPULAR_KEYWORDS_LIMIT,
+      `${MINIMUN_SEARCH_COUNT}`,
+      POPULAR_KEYWORDS_LIMIT,
+      POPULAR_KEYWORDS_LIMIT,
+    ],
+  );
+
+  const items: PopularSearchKeyword[] = popularKeywords.map(
+    (item: SearchKeyword, index: number) => {
+      const preRank = lastPopular.indexOf(item.keyword);
+      return {
+        searchKeyword: item.keyword,
+        rankingChange: preRank === -1 ? null : index - preRank,
+      };
+    },
+  );
+  lastPopular = items.map((item) => item.searchKeyword);
+
+  return items;
+};

--- a/backend/src/v1/search-keywords/search-keywords.type.ts
+++ b/backend/src/v1/search-keywords/search-keywords.type.ts
@@ -1,0 +1,8 @@
+export type SearchKeyword = {
+  keyword: string;
+};
+
+export type PopularSearchKeyword = {
+  searchKeyword: string;
+  rankingChange: number | null;
+};


### PR DESCRIPTION
### 개요

- #710

### 작업 사항

- 인기 검색어 API 로직 구현
  - 현재 순위 등락은 API 호출 바로 이전 시점과 비교하여 반환
  - 추후 특정 시간마다 순위를 저장하고, 해당 시점과 비교하여 순위 등락을 반환하는 방식으로 변경할 예정
- 인기 검색어 API swagger 추가
  - endpoint: `/seach-keywords/popular`

### 변경점
- v1 에 search-keywords를 추가하였습니다.

### 목적
- 집현전 페이지에 인기 검색어 순위를 보여줄 예정