### PR TITLE
feat: 검색결과 미리보기

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -60,6 +60,7 @@
     "dotenv": "^16.0.0",
     "express": "^4.17.2",
     "express-rate-limit": "^6.9.0",
+    "hangul-js": "^0.2.6",
     "http-errors": "^2.0.0",
     "http-status": "^1.5.0",
     "http-terminator": "^3.2.0",

--- a/backend/src/v1/routes/searchKeywords.routes.ts
+++ b/backend/src/v1/routes/searchKeywords.routes.ts
@@ -1,21 +1,8 @@
 import { Router } from 'express';
 import { searchKeywordsAutocomplete, getPopularSearchKeywords } from '../search-keywords/searchKeywords.controller';
-import rateLimit from 'express-rate-limit';
 
 export const path = '/search-keywords';
 export const router = Router();
-
-/**
- * TODO
- * 초당 요청할수 있는 api회수인듯 싶다. 
- * 검색결과 미리보기에서는 어떻게 활용할지 고려필요
- * 매직넘버 환경변수나 const 변수로 대체할지 고민 필요.
- */
-// const limiter = rateLimit({
-//   windowMs: 60 * 1000, // 1분
-//   max: 100, // 1분에 100번
-//   message: '너무 많은 요청을 보냈습니다. 잠시 후 다시 시도해주세요.',
-// });
 
 router
   /**
@@ -147,12 +134,8 @@ router
    *                    items:
    *                      type: object
    *                      properties:
-   *                        book_info_id:
-   *                          description: 검색어
-   *                          type: string
-   *                        title:
-   *                          description: 책 이름
-   *                          type: string
+   *        import rateLimit from 'express-rate-limit';
+                       type: string
    *                        author:
    *                          description: 저자 이름
    *                          type: string

--- a/backend/src/v1/routes/searchKeywords.routes.ts
+++ b/backend/src/v1/routes/searchKeywords.routes.ts
@@ -1,8 +1,21 @@
 import { Router } from 'express';
-import { getPopularSearchKeywords } from '../search-keywords/searchKeywords.controller';
+import { searchKeywordsAutocomplete, getPopularSearchKeywords } from '../search-keywords/searchKeywords.controller';
+import rateLimit from 'express-rate-limit';
 
 export const path = '/search-keywords';
 export const router = Router();
+
+/**
+ * TODO
+ * 초당 요청할수 있는 api회수인듯 싶다. 
+ * 검색결과 미리보기에서는 어떻게 활용할지 고려필요
+ * 매직넘버 환경변수나 const 변수로 대체할지 고민 필요.
+ */
+// const limiter = rateLimit({
+//   windowMs: 60 * 1000, // 1분
+//   max: 100, // 1분에 100번
+//   message: '너무 많은 요청을 보냈습니다. 잠시 후 다시 시도해주세요.',
+// });
 
 router
   /**
@@ -46,3 +59,14 @@ router
    *                          type: integer
    */
   .get('/popular', getPopularSearchKeywords);
+
+router
+  /**
+   * @openapi
+   * TODO swagger
+   * /api/search-keywords/autocomplete
+   * e.g)
+   *   http://localhost:3000/api/search-keywords/autocomplete?keyword=파이썬
+   */
+  .get('/autocomplete', searchKeywordsAutocomplete);
+

--- a/backend/src/v1/routes/searchKeywords.routes.ts
+++ b/backend/src/v1/routes/searchKeywords.routes.ts
@@ -61,12 +61,117 @@ router
   .get('/popular', getPopularSearchKeywords);
 
 router
-  /**
+   /**
    * @openapi
-   * TODO swagger
-   * /api/search-keywords/autocomplete
-   * e.g)
-   *   http://localhost:3000/api/search-keywords/autocomplete?keyword=파이썬
+   * /api/search-keywords/autocomplete:
+   *    get:
+   *      description: 검색창에서 검색어(초성 검색 가능)를 입력하면 해당 검색어에 대한 미리보기를 제공한다.
+   *      tags:
+   *      - search-keywords
+   *      parameters:
+   *      - name: keyword 
+   *        in: query
+   *        description: 검색어(초성검색 가능)
+   *        schema:
+   *          type: string
+   *      responses:
+   *        '200':
+   *          description: 검색결과 미리보기.
+   *                       검색결과 미리보기는 최대 12개까지 리턴해주며. 검색어를 결과가 없으면 0개가 리턴 될수 있다
+   *                       실제 검색 결과가 몇개인지도 totalCount라는 이름으로 제공한다.
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  items:
+   *                    type: array
+   *                    example:  [
+   *                               {
+   *                                  "book_info_id": 254,
+   *                                   "title": "자료구조(C언어로 쉽게 풀어 쓴)(개정판 3판)",
+   *                                   "author": "천인국, 공용해, 하상호",
+   *                                   "publisher": "생능출판",
+   *                                   "publishedAt": "2019-02-21T15:00:00.000Z",
+   *                                   "image": "https://image.kyobobook.co.kr/images/book/xlarge/716/x9788970509716.jpg"
+   *                                 },
+   *                                 {
+   *                                   "book_info_id": 948,
+   *                                   "title": "열혈강의 : 자료구조",
+   *                                   "author": "이상진",
+   *                                   "publisher": "프리렉",
+   *                                   "publishedAt": "2010-01-14T15:00:00.000Z",
+   *                                   "image": "https://image.kyobobook.co.kr/images/book/xlarge/022/x9788989345022.jpg"
+   *                                 },
+   *                                 {
+   *                                   "book_info_id": 945,
+   *                                   "title": "윤성우의 열혈 자료구조 ",
+   *                                   "author": "윤성우",
+   *                                   "publisher": "오렌지미디어",
+   *                                   "publishedAt": "2012-01-15T15:00:00.000Z",
+   *                                   "image": "https://image.kyobobook.co.kr/images/book/xlarge/067/x9788996094067.jpg"
+   *                                 },
+   *                                 {
+   *                                   "book_info_id": 199,
+   *                                   "title": "Do it! 자료구조와 함께 배우는 알고리즘 입문: C 언어 편",
+   *                                   "author": "보요 시바타",
+   *                                   "publisher": "이지스퍼블리싱",
+   *                                   "publishedAt": "2017-12-26T15:00:00.000Z",
+   *                                   "image": "https://image.kyobobook.co.kr/images/book/xlarge/130/x9791188612130.jpg"
+   *                                 },
+   *                                 {
+   *                                   "book_info_id": 209,
+   *                                   "title": "Do it! 자료구조와 함께 배우는 알고리즘 입문: 파이썬 편",
+   *                                   "author": "시바타 보요",
+   *                                   "publisher": "이지스퍼블리싱",
+   *                                   "publishedAt": "2020-07-19T15:00:00.000Z",
+   *                                   "image": "https://image.kyobobook.co.kr/images/book/xlarge/727/x9791163031727.jpg"
+   *                                 },
+   *                                 {
+   *                                   "book_info_id": 220,
+   *                                   "title": "C로 쓴 자료구조론(2판)",
+   *                                   "author": "HOROWITZ, Sahni, Anderson-Freed",
+   *                                   "publisher": "교보문고",
+   *                                   "publishedAt": "2008-02-09T15:00:00.000Z",
+   *                                   "image": "https://image.kyobobook.co.kr/images/book/xlarge/944/x9788970858944.jpg"
+   *                                 },
+   *                                 {
+   *                                   "book_info_id": 936,
+   *                                   "title": "(C++로 구현하는) 자료구조와 알고리즘",
+   *                                   "author": "Michael T. Goodrich",
+   *                                   "publisher": "한티에듀",
+   *                                   "publishedAt": "2013-08-30T15:00:00.000Z",
+   *                                   "image": "https://image.kyobobook.co.kr/images/book/xlarge/039/x9791190017039.jpg"
+   *                                 }
+   *                               ]
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        book_info_id:
+   *                          description: 검색어
+   *                          type: string
+   *                        title:
+   *                          description: 책 이름
+   *                          type: string
+   *                        author:
+   *                          description: 저자 이름
+   *                          type: string
+   *                        publisher:
+   *                          description: 출판사 이름
+   *                          type: string
+   *                        publishedAt:
+   *                          description: 출판일자
+   *                          type: string
+   *                        image:
+   *                          description: 책 표지 이미지 주소 링크
+   *                          type: string
+   *                  meta:
+   *                    type: object
+   *                    properties:
+   *                      totalCount:
+   *                        description: 전체 검색결과 수
+   *                        type: number
+   *                        example: 7
    */
   .get('/autocomplete', searchKeywordsAutocomplete);
 

--- a/backend/src/v1/search-keywords/searchKeywords.controller.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.controller.ts
@@ -145,9 +145,9 @@ export const searchKeywordsAutocomplete: any = async (
   }
 
   return res.status(status.OK).send({
-    result: {
-      fulltext: { length: result.length },
-    },
-    fulltext: result,
+    items: result,
+    meta: {
+      totalCount: result.length
+    }
   });
 }

--- a/backend/src/v1/search-keywords/searchKeywords.controller.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.controller.ts
@@ -5,6 +5,9 @@ import ErrorResponse from '~/v1/utils/error/errorResponse';
 import * as status from 'http-status';
 import * as searchKeywordsService from './searchKeywords.service';
 
+import { executeQuery } from '~/mysql';
+import * as hangul from 'hangul-js';
+
 export const getPopularSearchKeywords = async (
   req: Request,
   res: Response,
@@ -32,3 +35,119 @@ export const getPopularSearchKeywords = async (
     );
   }
 };
+
+
+const disassembleHangul = (original?: string) => {
+  if (!original) return null;
+  return hangul.d(original).join("");
+};
+
+const extractHangulCho = (original?: string) => {
+  if (!original) return null;
+  return hangul
+    .d(original, true)
+    .map((letter) => letter[0])
+    .join("");
+};
+
+/**SearchBookInfoQuery
+ * TODO search keyword preview
+ * 생쿼리를 날려서 확인 필요
+ * book.service 와의 연관성 확인 필요
+ * 보니까 service에서 query를 날리는 듯 싶다
+ */
+export const searchKeywordsAutocomplete: any = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+
+  // // URI에 있는 파라미터/쿼리 변수에 저장
+  const query = req.query?.query ?? '';
+  const {
+    keyword
+  } = req.query;
+  const LIMIT_OF_SEARCH_keyword_PREVIEW = 12;
+  
+  console.log(`query: ${query}`);
+  console.log(`keyword: ${keyword}`);
+
+  // 유효한 인자인지 파악
+  if (!keyword) {
+    return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
+  }
+
+  // keyword 비어 있을때에 대한 처리 필요, 초기화를 잘 할것. // keyword as string
+  let keyword_d = extractHangulCho(keyword as string)
+  let isCho = true;
+  if (keyword !== keyword_d) {
+    keyword_d = disassembleHangul(keyword as string);
+    isCho = false;
+  }
+  console.log(`keyword_d: ${keyword_d}`);
+  let result: any;
+  try {
+    if (isCho) {
+      result = await executeQuery(
+        `
+        (
+          SELECT id, title, author, publisher, publishedAt, image
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE MATCH(title_initials, author_initials, publisher_initials) AGAINST (? IN BOOLEAN MODE)
+          )
+      )
+      UNION (
+          SELECT id, title, author, publisher, publishedAt, image
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE title_initials LIKE ('%${keyword_d}%')
+                      OR author_initials LIKE ('%${keyword_d}%')
+                      OR publisher_initials LIKE ('%${keyword_d}%')
+          )
+      )
+      LIMIT ${LIMIT_OF_SEARCH_keyword_PREVIEW}
+        `,      [keyword_d]
+      );
+    } else {
+      result = await executeQuery(
+        `(
+          SELECT id, title, author, publisher, publishedAt, image
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
+          )
+      )
+      UNION (
+          SELECT id, title, author, publisher, publishedAt, image
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE disassembled_title LIKE ('%${keyword_d}%')
+                      OR disassembled_author LIKE ('%${keyword_d}%')
+                      OR disassembled_publisher LIKE ('%${keyword_d}%')
+          )
+      )
+      LIMIT ${LIMIT_OF_SEARCH_keyword_PREVIEW}
+      `,
+        [keyword_d]
+      );
+    }
+  } catch (error) {
+    return next(new ErrorResponse(errorCode.UNKNOWN_ERROR, status.INTERNAL_SERVER_ERROR));
+  }
+
+  return res.status(status.OK).send({
+    result: {
+      fulltext: { length: result.length },
+    },
+    fulltext: result,
+  });
+}

--- a/backend/src/v1/search-keywords/searchKeywords.controller.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.controller.ts
@@ -8,7 +8,6 @@ import * as status from 'http-status';
 import * as searchKeywordsService from './searchKeywords.service';
 
 import { executeQuery } from '~/mysql';
-import * as hangul from 'hangul-js';
 
 export const getPopularSearchKeywords = async (
   req: Request,
@@ -38,38 +37,32 @@ export const getPopularSearchKeywords = async (
   }
 };
 
-/**SearchBookInfoQuery
- * TODO search keyword preview
- * 생쿼리를 날려서 확인 필요
- * book.service 와의 연관성 확인 필요
- * 보니까 service에서 query를 날리는 듯 싶다
- */
 export const searchKeywordsAutocomplete: any = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
-
-  // // URI에 있는 파라미터/쿼리 변수에 저장
   const {
     keyword
   } = req.query;
   const LIMIT_OF_SEARCH_keyword_PREVIEW = 12;
 
-  // 유효한 인자인지 파악
   if (!keyword) {
-    return next(new ErrorResponse(errorCode.INVALID_INPUT, status.BAD_REQUEST));
+    return res.status(status.OK).send({
+      items: [],
+      meta: 
+        0
+    });
   }
 
-  // keyword 비어 있을때에 대한 처리 필요, 초기화를 잘 할것. // keyword as string
   let keyword_d = extractHangulInitials(keyword as string)
   let isCho = true;
   if (keyword !== keyword_d) {
     keyword_d = disassembleHangul(keyword as string);
     isCho = false;
   }
-  console.log(`keyword_d: ${keyword_d}`);
-  let result: any;
+
+  let result: any = [];
   let totalCount: number;
   try {
     if (isCho) {

--- a/backend/src/v1/search-keywords/searchKeywords.controller.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.controller.ts
@@ -1,13 +1,11 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { extractHangulInitials, disassembleHangul } from '~/v1/utils/disassembleKeywords';
 import { logger } from '~/logger';
 import * as errorCode from '~/v1/utils/error/errorCode';
 import ErrorResponse from '~/v1/utils/error/errorResponse';
 import * as status from 'http-status';
 import * as searchKeywordsService from './searchKeywords.service';
 
-import { executeQuery } from '~/mysql';
 
 export const getPopularSearchKeywords = async (
   req: Request,
@@ -45,7 +43,6 @@ export const searchKeywordsAutocomplete: any = async (
   const {
     keyword
   } = req.query;
-  const LIMIT_OF_SEARCH_keyword_PREVIEW = 12;
 
   if (!keyword) {
     return res.status(status.OK).send({
@@ -54,128 +51,10 @@ export const searchKeywordsAutocomplete: any = async (
         0
     });
   }
-
-  let keyword_d = extractHangulInitials(keyword as string)
-  let isCho = true;
-  if (keyword !== keyword_d) {
-    keyword_d = disassembleHangul(keyword as string);
-    isCho = false;
-  }
-
-  let result: any = [];
-  let totalCount: number;
   try {
-    if (isCho) {
-      result = await executeQuery(
-        `
-        (
-          SELECT id as book_info_id, title, author, publisher, publishedAt, image
-          FROM book_info
-          WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE MATCH(title_initials, author_initials, publisher_initials) AGAINST (? IN BOOLEAN MODE)
-          )
-      )
-      UNION (
-          SELECT id as book_info_id, title, author, publisher, publishedAt, image
-          FROM book_info
-          WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE title_initials LIKE ('%${keyword_d}%')
-                      OR author_initials LIKE ('%${keyword_d}%')
-                      OR publisher_initials LIKE ('%${keyword_d}%')
-          )
-      )
-      LIMIT ${LIMIT_OF_SEARCH_keyword_PREVIEW}
-        `,      [keyword_d]
-      );
-      totalCount = await executeQuery(
-        `SELECT COUNT(*) AS totalCount FROM (
-          (
-            SELECT id
-            FROM book_info
-            WHERE id IN (
-                SELECT book_info_id
-                FROM book_info_search_keywords
-                WHERE MATCH(title_initials, author_initials, publisher_initials) AGAINST (? IN BOOLEAN MODE)
-            )
-        )
-        UNION (
-            SELECT id
-            FROM book_info
-            WHERE id IN (
-                SELECT book_info_id
-                FROM book_info_search_keywords
-                WHERE title_initials LIKE ('%${keyword_d}%')
-                        OR author_initials LIKE ('%${keyword_d}%')
-                        OR publisher_initials LIKE ('%${keyword_d}%')
-            )
-        )) AS COUNT_SET`,      [keyword_d]
-        ).then((result) => {
-          return result[0]
-        });
-    } else {
-      result = await executeQuery(
-        
-        `(
-          SELECT id as book_info_id, title, author, publisher, publishedAt, image         
-          FROM book_info
-          WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
-          )
-      )
-      UNION (
-          SELECT id as book_info_id, title, author, publisher, publishedAt, image         
-          FROM book_info
-          WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE disassembled_title LIKE ('%${keyword_d}%')
-                      OR disassembled_author LIKE ('%${keyword_d}%')
-                      OR disassembled_publisher LIKE ('%${keyword_d}%')
-          )
-      )
-      LIMIT ${LIMIT_OF_SEARCH_keyword_PREVIEW}
-        `,      [keyword_d]
-      );
-      totalCount = await executeQuery(
-        `SELECT COUNT(*) AS totalCount FROM (
-          (
-            SELECT id
-            FROM book_info
-            WHERE id IN (
-                SELECT book_info_id
-                FROM book_info_search_keywords
-                WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
-            )
-        )
-        UNION (
-            SELECT id
-            FROM book_info
-            WHERE id IN (
-                SELECT book_info_id
-                FROM book_info_search_keywords
-                WHERE disassembled_title LIKE ('%${keyword_d}%')
-                        OR disassembled_author LIKE ('%${keyword_d}%')
-                        OR disassembled_publisher LIKE ('%${keyword_d}%')
-            )
-        )) AS COUNT_SET`,      [keyword_d]
-      ).then((result) => {
-        return result[0]
-      });
-      
-    }
+    const items = await searchKeywordsService.getSearchAutocompletePreviewResult(keyword as string);
+    return res.status(status.OK).send( items );
   } catch (error) {
     return next(new ErrorResponse(errorCode.UNKNOWN_ERROR, status.INTERNAL_SERVER_ERROR));
   }
-
-  return res.status(status.OK).send({
-    items: result,
-    meta: 
-      totalCount
-  });
 }

--- a/backend/src/v1/search-keywords/searchKeywords.controller.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.controller.ts
@@ -6,7 +6,6 @@ import ErrorResponse from '~/v1/utils/error/errorResponse';
 import * as status from 'http-status';
 import * as searchKeywordsService from './searchKeywords.service';
 
-
 export const getPopularSearchKeywords = async (
   req: Request,
   res: Response,

--- a/backend/src/v1/search-keywords/searchKeywords.service.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.service.ts
@@ -1,6 +1,8 @@
 import { makeExecuteQuery, pool } from '~/mysql';
 import { logger } from '~/logger';
 import { PopularSearchKeyword, SearchKeyword } from './searchKeywords.type';
+import { extractHangulInitials, disassembleHangul } from '~/v1/utils/disassembleKeywords';
+import { executeQuery } from '~/mysql';
 import * as searchKeywordRepository from './searchKeywords.repository';
 
 const LEAST_SEARCH_COUNT = 5;
@@ -100,3 +102,129 @@ export const createSearchKeywordLog = async (
     connection.release();
   }
 };
+
+
+export const getSearchAutocompletePreviewResult = async (
+  keyword: string
+) => {
+  const LIMIT_OF_SEARCH_keyword_PREVIEW = 12;
+  let keyword_d = extractHangulInitials(keyword as string)
+  let isCho = true;
+
+  if (keyword !== keyword_d) {
+    keyword_d = disassembleHangul(keyword as string);
+    isCho = false;
+  }
+
+  let result: any = [];
+  let totalCount: number;
+  if (isCho) {
+    result = await executeQuery(
+      `
+      (
+        SELECT id as book_info_id, title, author, publisher, publishedAt, image
+        FROM book_info
+        WHERE id IN (
+            SELECT book_info_id
+            FROM book_info_search_keywords
+            WHERE MATCH(title_initials, author_initials, publisher_initials) AGAINST (? IN BOOLEAN MODE)
+        )
+    )
+    UNION (
+        SELECT id as book_info_id, title, author, publisher, publishedAt, image
+        FROM book_info
+        WHERE id IN (
+            SELECT book_info_id
+            FROM book_info_search_keywords
+            WHERE title_initials LIKE ('%${keyword_d}%')
+                    OR author_initials LIKE ('%${keyword_d}%')
+                    OR publisher_initials LIKE ('%${keyword_d}%')
+        )
+    )
+    LIMIT ${LIMIT_OF_SEARCH_keyword_PREVIEW}
+      `,      [keyword_d]
+    );
+    totalCount = await executeQuery(
+      `SELECT COUNT(*) AS totalCount FROM (
+        (
+          SELECT id
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE MATCH(title_initials, author_initials, publisher_initials) AGAINST (? IN BOOLEAN MODE)
+          )
+      )
+      UNION (
+          SELECT id
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE title_initials LIKE ('%${keyword_d}%')
+                      OR author_initials LIKE ('%${keyword_d}%')
+                      OR publisher_initials LIKE ('%${keyword_d}%')
+          )
+      )) AS COUNT_SET`,      [keyword_d]
+      ).then((result) => {
+        return result[0]
+      });
+  } else {
+    result = await executeQuery(
+      
+      `(
+        SELECT id as book_info_id, title, author, publisher, publishedAt, image         
+        FROM book_info
+        WHERE id IN (
+            SELECT book_info_id
+            FROM book_info_search_keywords
+            WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
+        )
+    )
+    UNION (
+        SELECT id as book_info_id, title, author, publisher, publishedAt, image         
+        FROM book_info
+        WHERE id IN (
+            SELECT book_info_id
+            FROM book_info_search_keywords
+            WHERE disassembled_title LIKE ('%${keyword_d}%')
+                    OR disassembled_author LIKE ('%${keyword_d}%')
+                    OR disassembled_publisher LIKE ('%${keyword_d}%')
+        )
+    )
+    LIMIT ${LIMIT_OF_SEARCH_keyword_PREVIEW}
+      `,      [keyword_d]
+    );
+    totalCount = await executeQuery(
+      `SELECT COUNT(*) AS totalCount FROM (
+        (
+          SELECT id
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
+          )
+      )
+      UNION (
+          SELECT id
+          FROM book_info
+          WHERE id IN (
+              SELECT book_info_id
+              FROM book_info_search_keywords
+              WHERE disassembled_title LIKE ('%${keyword_d}%')
+                      OR disassembled_author LIKE ('%${keyword_d}%')
+                      OR disassembled_publisher LIKE ('%${keyword_d}%')
+          )
+      )) AS COUNT_SET`,      [keyword_d]
+    ).then((result) => {
+      return result[0]
+    });
+    
+  }
+  return {
+    items: result,
+    meta: 
+      totalCount
+  };
+}


### PR DESCRIPTION
### 개요
- 검색창에 검색하고자 하는 내용을 일부만 적거나 초성만 입력하더라도 검색결과 미리보기를 제공함
- 검색결과 미리보기 API작업

### 작업 사항
- 별도로 구성한 검색어 테이블을 이용하여 검색(초성과 글자를 자음, 모음으로 분리한 데이터를 가짐)

### 변경점
- hangul-js 패키지 설치됨 (초성 분리, 자음모음 분리에 사용)
- search-keyword

