### PR TITLE
fix(build): 도커파일에서 `patches/` 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ WORKDIR /app
 
 FROM pnpm-installed as workspace
 COPY ./pnpm-lock.yaml .
-COPY patches patches
 
 RUN pnpm fetch
 

--- a/docs/docs/explanation.md
+++ b/docs/docs/explanation.md
@@ -15,7 +15,6 @@
 ├── database # 배포/로컬 mysql 데이터베이스 (주의: 업데이트/테스트되지 않음)
 ├── docs # 개발 가이드
 ├── nginx # nginx 설정 파일
-├── patches # 문제가 있는 패키지를 수정한 패치 파일
 └── scripts # AWS 배포 이후 docker-compose 실행용 스크립트
 ```
 


### PR DESCRIPTION
## 원인

#670 의 https://github.com/jiphyeonjeon-42/backend/pull/670/commits/87ad0079a31acc810b3ef934520cbc379d1972bf 에서 ts-rest를 버전업 하면서 `patches/`를 제거한 것이 도커파일에 반영되지 않음
