### PR TITLE
feat: V1 책 정보 검색 조건 확장 및 검색 로그 저장

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -60,6 +60,7 @@
     "dotenv": "^16.0.0",
     "express": "^4.17.2",
     "express-rate-limit": "^6.9.0",
+    "hangul-js": "^0.2.6",
     "http-errors": "^2.0.0",
     "http-status": "^1.5.0",
     "http-terminator": "^3.2.0",

--- a/backend/src/v1/books/books.controller.ts
+++ b/backend/src/v1/books/books.controller.ts
@@ -99,7 +99,8 @@ export const searchBookInfo = async (
   next: NextFunction,
 ) => {
   // URI에 있는 파라미터/쿼리 변수에 저장
-  const query = req.query?.query ?? '';
+  let query = req.query?.query ?? '';
+  query = query.trim();
   const {
     page, limit, sort, category,
   } = req.query;

--- a/backend/src/v1/books/books.service.ts
+++ b/backend/src/v1/books/books.service.ts
@@ -8,6 +8,10 @@ import { executeQuery } from '~/mysql';
 import * as errorCode from '~/v1/utils/error/errorCode';
 import { StringRows } from '~/v1/utils/types';
 import { VSearchBookByTag } from '~/entity/entities';
+import {
+  disassembleHangul,
+  extractHangulInitials,
+} from '~/v1/utils/disassembleKeywords';
 import * as models from './books.model';
 import BooksRepository from './books.repository';
 import {
@@ -18,6 +22,7 @@ import { categoryWithBookCount } from '../DTO/common.interface';
 import { Project, RawProject } from '../DTO/cursus.model';
 import UsersRepository from '../users/users.repository';
 import ErrorResponse from '../utils/error/errorResponse';
+import { createSearchKeywordLog } from '../search-keywords/searchKeywords.service';
 
 const getInfoInNationalLibrary = async (isbn: string) => {
   let book;
@@ -157,7 +162,38 @@ export const searchInfo = async (
   sort: string,
   category: string,
 ) => {
-  let ordering = '';
+  console.time('search book info');
+  const disassemble = query ? disassembleHangul(query) : '';
+  const initials = query ? extractHangulInitials(query) : '';
+
+  let matchScore: string;
+  let searchCondition: string;
+  if (!query) {
+    matchScore = '';
+    searchCondition = 'TRUE';
+  } else if (query === initials) {
+    matchScore = `MATCH(book_info_search_keywords.title_initials,
+      book_info_search_keywords.author_initials,
+      book_info_search_keywords.publisher_initials)
+      AGAINST ('${initials}' IN BOOLEAN MODE)`;
+    searchCondition = `book_info.isbn LIKE '%${query}%'
+      OR book_info_search_keywords.title_initials LIKE '%${initials}%'
+      OR book_info_search_keywords.author_initials LIKE '%${initials}%'
+      OR book_info_search_keywords.publisher_initials LIKE '%${initials}%'
+      OR ${matchScore}`;
+  } else {
+    matchScore = `MATCH(book_info_search_keywords.disassembled_title,
+      book_info_search_keywords.disassembled_author,
+      book_info_search_keywords.disassembled_publisher)
+      AGAINST ('${disassemble}' IN BOOLEAN MODE)`;
+    searchCondition = `book_info.isbn LIKE '%${query}%'
+      OR book_info_search_keywords.disassembled_title LIKE '%${disassemble}%'
+      OR book_info_search_keywords.disassembled_author LIKE '%${disassemble}%'
+      OR book_info_search_keywords.disassembled_publisher LIKE '%${disassemble}%'
+      OR ${matchScore}`;
+  }
+
+  let ordering: string;
   switch (sort) {
     case 'title':
       ordering = 'ORDER BY book_info.title';
@@ -165,9 +201,16 @@ export const searchInfo = async (
     case 'popular':
       ordering = 'ORDER BY lendingCnt DESC, book_info.title';
       break;
-    default:
+    case 'new':
       ordering = 'ORDER BY book_info.createdAt DESC, book_info.title';
+      break;
+    default:
+      ordering = matchScore
+        ? `ORDER BY ${matchScore} DESC, book_info.title`
+        : 'ORDER BY book_info.title';
+      break;
   }
+
   const categoryResult = (await executeQuery(
     `
     SELECT name
@@ -178,7 +221,9 @@ export const searchInfo = async (
   )) as StringRows[];
   const categoryName = categoryResult?.[0]?.name;
   const categoryWhere = categoryName ? `category.name = '${categoryName}'` : 'TRUE';
-  const categoryList = (await executeQuery(
+  const categoryHaving = categoryName ? `category = '${categoryName}'` : 'TRUE';
+
+  const categoryListPromise = executeQuery(
     `
     SELECT name, count FROM (
     SELECT
@@ -186,18 +231,16 @@ export const searchInfo = async (
       count(category.name) AS count
     FROM book_info
     RIGHT JOIN category ON book_info.categoryId = category.id
-    WHERE (
-      book_info.title LIKE ?
-      OR book_info.author LIKE ?
-      OR book_info.isbn LIKE ?
-      )
+    LEFT JOIN book_info_search_keywords
+      ON book_info.id = book_info_search_keywords.book_info_id
+    WHERE (${searchCondition})
     GROUP BY category.name WITH ROLLUP) as a
     ORDER BY name ASC;
-  `,
-    [`%${query}%`, `%${query}%`, `%${query}%`],
-  )) as models.categoryCount[];
-  const categoryHaving = categoryName ? `category = '${categoryName}'` : 'TRUE';
-  const bookList = (await executeQuery(
+    `,
+    [],
+  ) as Promise<models.categoryCount[]>;
+
+  const bookListPromise = executeQuery(
     `
     SELECT
       book_info.id AS id,
@@ -218,35 +261,37 @@ export const searchInfo = async (
         SELECT COUNT(id) FROM lending WHERE lending.bookId = book_info.id
       ) as lendingCnt
     FROM book_info
-    WHERE
-    (
-      book_info.title like ?
-      OR book_info.author like ?
-      OR book_info.isbn like ?
-    )
+    LEFT JOIN book_info_search_keywords
+      ON book_info.id = book_info_search_keywords.book_info_id
+    WHERE (${searchCondition})
     GROUP BY book_info.id
     HAVING ${categoryHaving}
     ${ordering}
     LIMIT ?
     OFFSET ?;
   `,
-    [`%${query}%`, `%${query}%`, `%${query}%`, limit, page * limit],
-  )) as models.BookInfo[];
+    [limit, page * limit],
+  ) as Promise<models.BookInfo[]>;
 
-  const totalItems = (await executeQuery(
+  const totalItemsPromise = executeQuery(
     `
     SELECT
       count(category.name) AS count
     FROM book_info
     LEFT JOIN category ON book_info.categoryId = category.id
-    WHERE (
-      book_info.title LIKE ?
-      OR book_info.author LIKE ?
-      OR book_info.isbn LIKE ?
-      ) AND (${categoryWhere})
+    LEFT JOIN book_info_search_keywords
+      ON book_info.id = book_info_search_keywords.book_info_id
+    WHERE (${searchCondition}) AND (${categoryWhere})
   `,
-    [`%${query}%`, `%${query}%`, `%${query}%`],
-  ))[0].count as number;
+    [],
+  ).then((result) => result[0].count) as Promise<number>;
+
+  const [categoryList, bookList, totalItems] = await Promise.all([
+    categoryListPromise,
+    bookListPromise,
+    totalItemsPromise,
+    createSearchKeywordLog(query, disassemble, initials),
+  ]);
 
   const meta = {
     totalItems,
@@ -255,6 +300,8 @@ export const searchInfo = async (
     totalPages: Math.ceil(totalItems / limit),
     currentPage: page + 1,
   };
+  console.timeEnd('search book info');
+
   return { items: bookList, categories: categoryList, meta };
 };
 

--- a/backend/src/v1/books/books.service.ts
+++ b/backend/src/v1/books/books.service.ts
@@ -162,7 +162,6 @@ export const searchInfo = async (
   sort: string,
   category: string,
 ) => {
-  console.time('search book info');
   const disassemble = query ? disassembleHangul(query) : '';
   const initials = query ? extractHangulInitials(query) : '';
 
@@ -309,7 +308,6 @@ export const searchInfo = async (
     totalPages: Math.ceil(totalItems / limit),
     currentPage: page + 1,
   };
-  console.timeEnd('search book info');
 
   return { items: bookList, categories: categoryList, meta };
 };

--- a/backend/src/v1/search-keywords/searchKeywords.service.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.service.ts
@@ -67,7 +67,6 @@ export const createSearchKeywordLog = async (
       `,
       [keyword],
     );
-    console.log(searchKeyword);
 
     let searchKeywordId = searchKeyword?.id;
     if (!searchKeyword) {

--- a/backend/src/v1/search-keywords/searchKeywords.service.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.service.ts
@@ -1,4 +1,6 @@
-import { PopularSearchKeyword } from './searchKeywords.type';
+import { makeExecuteQuery, pool } from '~/mysql';
+import { logger } from '~/logger';
+import { PopularSearchKeyword, SearchKeyword } from './searchKeywords.type';
 import * as searchKeywordRepository from './searchKeywords.repository';
 
 const LEAST_SEARCH_COUNT = 5;
@@ -7,7 +9,10 @@ let lastPopular: string[] = [];
 
 const updateLastPopular = (items: string[]) => {
   lastPopular = [...items];
-  console.log(`(${new Date().toLocaleString()}) Popular Search Keywords `, lastPopular);
+  logger.debug(
+    `(${new Date().toLocaleString()}) Popular Search Keywords `,
+    lastPopular,
+  );
 };
 
 export const getPopularSearchKeywords = async () => {
@@ -40,4 +45,59 @@ export const renewLastPopular = async () => {
     POPULAR_RANKING_LIMIT,
   );
   updateLastPopular(popularKeywords.map((item) => item.keyword));
+};
+
+export const createSearchKeywordLog = async (
+  keyword: string,
+  disassemble: string,
+  initials: string,
+) => {
+  if (!keyword) return;
+
+  const connection = await pool.getConnection();
+  const transactionExecuteQuery = makeExecuteQuery(connection);
+
+  try {
+    await connection.beginTransaction();
+    const [searchKeyword]: [SearchKeyword | undefined] = await transactionExecuteQuery(
+      `
+      SELECT id, keyword
+      FROM search_keywords
+      WHERE keyword = ?
+      `,
+      [keyword],
+    );
+    console.log(searchKeyword);
+
+    let searchKeywordId = searchKeyword?.id;
+    if (!searchKeyword) {
+      const { insertId }: { insertId: number } = await transactionExecuteQuery(
+        `
+        INSERT INTO search_keywords
+        (keyword, disassembled_keyword, initial_consonants)
+        VALUES (?, ?, ?)
+        `,
+        [keyword, disassemble, initials],
+      );
+      searchKeywordId = insertId;
+    }
+
+    await transactionExecuteQuery(
+      `
+      INSERT INTO search_logs
+      (search_keyword_id)
+      VALUES (?)
+      `,
+      [searchKeywordId],
+    );
+
+    await connection.commit();
+  } catch (error) {
+    await connection.rollback();
+    if (error instanceof Error) {
+      throw error;
+    }
+  } finally {
+    connection.release();
+  }
 };

--- a/backend/src/v1/search-keywords/searchKeywords.type.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.type.ts
@@ -1,4 +1,5 @@
 export type SearchKeyword = {
+  id?: number;
   keyword: string;
 };
 

--- a/backend/src/v1/utils/disassembleKeywords.ts
+++ b/backend/src/v1/utils/disassembleKeywords.ts
@@ -1,0 +1,10 @@
+import hangul from 'hangul-js';
+
+export const disassembleHangul = (original: string) =>
+  hangul.d(original).join('');
+
+export const extractHangulInitials = (original: string) =>
+  hangul
+    .d(original, true)
+    .map((letter) => letter[0])
+    .join('');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -63,6 +63,9 @@ importers:
       express-rate-limit:
         specifier: ^6.9.0
         version: 6.9.0(express@4.17.2)
+      hangul-js:
+        specifier: ^0.2.6
+        version: 0.2.6
       http-errors:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3752,6 +3755,10 @@ packages:
     optionalDependencies:
       uglify-js: 3.17.4
     dev: true
+
+  /hangul-js@0.2.6:
+    resolution: {integrity: sha512-48axU8LgjCD30FEs66Xc04/8knxMwCMQw0f67l67rlttW7VXT3qRJgQeHmhiuGwWXGvSbk6YM0fhQlcjE1JFQA==}
+    dev: false
 
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}


### PR DESCRIPTION
### 개요
- #722 

### 작업 사항
- 책 정보를 검색할 때 초성 검색, 자음 모음을 분리하여 검색할 수 있도록 수정했습니다.
- MySQL의 전문 검색 기능을 활용합니다.

### 변경점
- 책 정보 검색 결과에 단순 부분 일치 뿐만 아니라 전문 검색 기능을 통해 나온 결과물도 포함했습니다.
- 하나의 검색어로 도서명, 저자명, 출판사명을 동시 검색 가능합니다.

### 목적
- 책을 검색했을 때 더 많은 결과물을 보여주기 위함입니다.
