### PR TITLE
feat: 책 등록 시 책 검색용 키워드 저장

### DIFF
--- a/backend/src/entity/entities/BookInfoSearchKeywords.ts
+++ b/backend/src/entity/entities/BookInfoSearchKeywords.ts
@@ -1,0 +1,36 @@
+import {
+  Column, Entity, Index, JoinColumn, OneToOne, PrimaryGeneratedColumn,
+} from 'typeorm';
+import { BookInfo } from './BookInfo';
+
+@Index('bookInfoId', ['bookInfoId'], {})
+@Entity('book_info_search_keywords')
+export class BookInfoSearchKeywords {
+  @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
+    id?: number;
+
+  @Column('varchar', { name: 'disassembled_title', length: 255 })
+    disassembledTitle?: string;
+
+  @Column('varchar', { name: 'disassembled_author', length: 255 })
+    disassembledAuthor?: string;
+
+  @Column('varchar', { name: 'disassembled_publisher', length: 255 })
+    disassembledPublisher?: string;
+
+  @Column('varchar', { name: 'title_initials', length: 255 })
+    titleInitials?: string;
+
+  @Column('varchar', { name: 'author_initials', length: 255 })
+    authorInitials?: string;
+
+  @Column('varchar', { name: 'publisher_initials', length: 255 })
+    publisherInitials?: string;
+
+  @Column('int', { name: 'book_info_id' })
+    bookInfoId?: number;
+
+  @OneToOne(() => BookInfo, (bookInfo) => bookInfo.id)
+  @JoinColumn([{ name: 'book_info_id', referencedColumnName: 'id' }])
+    bookInfo?: BookInfo;
+}

--- a/backend/src/entity/entities/index.ts
+++ b/backend/src/entity/entities/index.ts
@@ -1,5 +1,6 @@
 export * from './Book.ts';
 export * from './BookInfo.ts';
+export * from './BookInfoSearchKeywords.ts';
 export * from './Category.ts';
 export * from './Lending.ts';
 export * from './Likes.ts';

--- a/backend/src/v1/search-keywords/booksInfoSearchKeywords.repository.ts
+++ b/backend/src/v1/search-keywords/booksInfoSearchKeywords.repository.ts
@@ -1,0 +1,43 @@
+import { QueryRunner, Repository } from 'typeorm';
+import jipDataSource from '~/app-data-source';
+import { BookInfo, BookInfoSearchKeywords } from '~/entity/entities';
+import {
+  disassembleHangul,
+  extractHangulInitials,
+} from '../utils/disassembleKeywords';
+
+class BookInfoSearchKeywordRepository extends Repository<BookInfoSearchKeywords> {
+  constructor(transactionQueryRunner?: QueryRunner) {
+    const queryRunner = transactionQueryRunner;
+    const entityManager = jipDataSource.createEntityManager(queryRunner);
+    super(BookInfoSearchKeywords, entityManager);
+  }
+
+  async createBookInfoSearchKeyword(
+    target: BookInfo,
+  ): Promise<BookInfoSearchKeywords> {
+    const {
+      id, title, author, publisher,
+    } = target;
+
+    const disassembledTitle = disassembleHangul(title);
+    const titleInitials = extractHangulInitials(title);
+    const disassembledAuthor = disassembleHangul(author);
+    const authorInitials = extractHangulInitials(author);
+    const disassembledPublisher = disassembleHangul(publisher);
+    const publisherInitials = extractHangulInitials(publisher);
+
+    const bookInfoSearchKeyword: BookInfoSearchKeywords = {
+      bookInfoId: id,
+      disassembledTitle,
+      titleInitials,
+      disassembledAuthor,
+      authorInitials,
+      disassembledPublisher,
+      publisherInitials,
+    };
+    return this.save(bookInfoSearchKeyword);
+  }
+}
+
+export default BookInfoSearchKeywordRepository;

--- a/backend/src/v1/utils/disassembleKeywords.ts
+++ b/backend/src/v1/utils/disassembleKeywords.ts
@@ -1,10 +1,14 @@
 import hangul from 'hangul-js';
 
-export const disassembleHangul = (original: string) =>
-  hangul.d(original).join('');
+export const disassembleHangul = (original: string | undefined) => {
+  if (!original) return '';
+  return hangul.d(original).join('');
+};
 
-export const extractHangulInitials = (original: string) =>
-  hangul
+export const extractHangulInitials = (original: string | undefined) => {
+  if (!original) return '';
+  return hangul
     .d(original, true)
     .map((letter) => letter[0])
     .join('');
+};


### PR DESCRIPTION
### 개요
- #726

### 작업 사항
- bookInfoSearchKeyword 엔티티, 리포지토리, createBookInfoSearchKeyword create 함수 추가
- 책 등록하는 트랜젝션에 createBookInfoSearchKeyword 함수 추가

### 변경점
- 책을 등록할 때 책 검색용 키워드도 함께 저장되는 로직이 추가 되었습니다.
- 책을 등록하는 로직이 이미 트랜잭션 처리 되고 있었고, typeORM을 사용하고 있었기 때문에, bookInfoSearchKeyword도 같은 방식으로  처리할 수 있도록 만들었습니다.

### 목적
- 책을 등록하는 동시에 bookInfoSearchKeyword를 저장하여 bookInfoSearchKeyword를 별도로 저장할 필요없게 만듭니다.

