### PR TITLE
refactor: search keyword와 search log type orm 적용

### DIFF
--- a/backend/src/entity/entities/BookInfo.ts
+++ b/backend/src/entity/entities/BookInfo.ts
@@ -1,5 +1,12 @@
 import {
-  Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn,
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Book } from './Book';
 import { Category } from './Category';
@@ -7,6 +14,7 @@ import { Likes } from './Likes';
 import { Reservation } from './Reservation';
 import { Reviews } from './Reviews';
 import { SuperTag } from './SuperTag';
+import { BookInfoSearchKeywords } from '.';
 
 @Index('categoryId', ['categoryId'], {})
 @Entity('book_info')
@@ -68,4 +76,10 @@ export class BookInfo {
 
   @OneToMany(() => SuperTag, (superTags) => superTags.userId)
     superTags?: SuperTag[];
+
+  @OneToOne(
+    () => BookInfoSearchKeywords,
+    (bookInfoSearchKeyword) => bookInfoSearchKeyword.bookInfo,
+  )
+    bookInfoSearchKeyword?: BookInfoSearchKeywords;
 }

--- a/backend/src/entity/entities/BookInfo.ts
+++ b/backend/src/entity/entities/BookInfo.ts
@@ -14,7 +14,7 @@ import { Likes } from './Likes';
 import { Reservation } from './Reservation';
 import { Reviews } from './Reviews';
 import { SuperTag } from './SuperTag';
-import { BookInfoSearchKeywords } from '.';
+import { BookInfoSearchKeywords } from './BookInfoSearchKeywords';
 
 @Index('categoryId', ['categoryId'], {})
 @Entity('book_info')

--- a/backend/src/entity/entities/BookInfoSearchKeywords.ts
+++ b/backend/src/entity/entities/BookInfoSearchKeywords.ts
@@ -3,7 +3,7 @@ import {
 } from 'typeorm';
 import { BookInfo } from './BookInfo';
 
-@Index('bookInfoId', ['bookInfoId'], {})
+@Index('FK_bookInfoId', ['bookInfoId'], {})
 @Entity('book_info_search_keywords')
 export class BookInfoSearchKeywords {
   @PrimaryGeneratedColumn({ type: 'int', name: 'id' })

--- a/backend/src/entity/entities/SearchKeywords.ts
+++ b/backend/src/entity/entities/SearchKeywords.ts
@@ -1,0 +1,22 @@
+import {
+  Column, Entity, OneToMany, PrimaryGeneratedColumn,
+} from 'typeorm';
+import { SearchLogs } from './SearchLogs';
+
+@Entity('search_keywords')
+export class SearchKeywords {
+  @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
+    id?: number;
+
+  @Column('varchar', { name: 'keyword', length: 255 })
+    keyword?: string;
+
+  @Column('varchar', { name: 'disassembled_keyword', length: 255 })
+    disassembledKeyword?: string;
+
+  @Column('varchar', { name: 'initial_consonants', length: 255 })
+    initialConsonants?: string;
+
+  @OneToMany(() => SearchLogs, (searchLogs) => searchLogs.searchKeyword)
+    searchLogs?: SearchLogs[];
+}

--- a/backend/src/entity/entities/SearchLogs.ts
+++ b/backend/src/entity/entities/SearchLogs.ts
@@ -1,0 +1,29 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { SearchKeywords } from './SearchKeywords';
+
+@Index('FK_searchKeywordId', ['searchKeywordId'], {})
+@Entity('search_logs')
+export class SearchLogs {
+  @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
+    id?: number;
+
+  @Column('int', { name: 'search_keyword_id' })
+    searchKeywordId?: number;
+
+  @Column('varchar', { name: 'timestamp', length: 255 })
+    timestamp?: string;
+
+  @ManyToOne(() => SearchKeywords, (SearchKeyword) => SearchKeyword.id, {
+    onDelete: 'NO ACTION',
+    onUpdate: 'NO ACTION',
+  })
+  @JoinColumn([{ name: 'search_keyword_id', referencedColumnName: 'id' }])
+    searchKeyword?: SearchKeywords;
+}

--- a/backend/src/entity/entities/index.ts
+++ b/backend/src/entity/entities/index.ts
@@ -6,6 +6,8 @@ export * from './Lending.ts';
 export * from './Likes.ts';
 export * from './Reservation.ts';
 export * from './Reviews.ts';
+export * from './SearchKeywords.ts';
+export * from './SearchLogs.ts';
 export * from './SubTag.ts';
 export * from './SuperTag.ts';
 export * from './User.ts';

--- a/backend/src/v1/search-keywords/searchKeywords.repository.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.repository.ts
@@ -1,59 +1,26 @@
-import { executeQuery } from '~/mysql';
-import { SearchKeyword } from './searchKeywords.type';
+import { QueryRunner, Repository } from 'typeorm';
+import jipDataSource from '~/app-data-source';
+import { SearchKeywords } from '~/entity/entities';
+import { CreateSearchKeyword, FindSearchKeyword } from './searchKeywords.type';
 
-export const getPopularSearchKeywords = async (
-  base: number, // 검색어를 집계할 날짜 기준. ex) 0: 현재 시각부터 집계, 1: 1일 전부터 집계
-  leastSearchCount: string,
-  popularRankingLimit: number,
-) => {
-  const popularSearchKeywords: SearchKeyword[] = await executeQuery(
-    `
-    (
-      SELECT keyword
-      FROM search_logs
-      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
-      WHERE search_logs.timestamp BETWEEN NOW() - INTERVAL 1 DAY - INTERVAL ? DAY AND NOW() - INTERVAL ? DAY 
-      GROUP BY search_keywords.keyword
-      HAVING COUNT(search_keywords.keyword) >= ?
-      ORDER BY COUNT(search_keywords.keyword) DESC, MAX(search_logs.timestamp) DESC
-      LIMIT ?
-    )
-    UNION
-    (
-      SELECT keyword
-      FROM search_logs
-      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
-      WHERE search_logs.timestamp BETWEEN NOW() - INTERVAL 1 MONTH - INTERVAL ? DAY AND NOW() - INTERVAL ? DAY 
-      GROUP BY search_keywords.keyword
-      HAVING COUNT(search_keywords.keyword) >= ?
-      ORDER BY COUNT(search_keywords.keyword) DESC, MAX(search_logs.timestamp) DESC
-      LIMIT ?
-    )
-    UNION
-    (
-      SELECT keyword
-      FROM search_logs
-      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
-      GROUP BY search_keywords.keyword
-      HAVING COUNT(search_keywords.keyword) >= ?
-      ORDER BY COUNT(search_keywords.keyword) desc, MAX(search_logs.timestamp) desc
-      LIMIT ?
-    )
-    LIMIT ?
-    `,
-    [
-      base,
-      base,
-      leastSearchCount,
-      popularRankingLimit,
-      base,
-      base,
-      leastSearchCount,
-      popularRankingLimit,
-      leastSearchCount,
-      popularRankingLimit,
-      popularRankingLimit,
-    ],
-  );
-  return popularSearchKeywords;
-};
+class SearchKeywordsRepository extends Repository<SearchKeywords> {
+  constructor(transactionQueryRunner?: QueryRunner) {
+    const queryRunner = transactionQueryRunner;
+    const entityManager = jipDataSource.createEntityManager(queryRunner);
+    super(SearchKeywords, entityManager);
+  }
+
+  async findSearchKeyword(where: FindSearchKeyword): Promise<SearchKeywords | null> {
+    const searchKeyword = await this.findOneBy({ ...where });
+    return searchKeyword;
+  }
+
+  async createSearchKeyword(target: CreateSearchKeyword): Promise<SearchKeywords> {
+    const searchLog: SearchKeywords = {
+      ...target,
+    };
+    return this.save(searchLog);
+  }
+}
+
+export default SearchKeywordsRepository;

--- a/backend/src/v1/search-keywords/searchKeywords.repository.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.repository.ts
@@ -15,11 +15,8 @@ class SearchKeywordsRepository extends Repository<SearchKeywords> {
     return searchKeyword;
   }
 
-  async createSearchKeyword(target: CreateSearchKeyword): Promise<SearchKeywords> {
-    const searchLog: SearchKeywords = {
-      ...target,
-    };
-    return this.save(searchLog);
+  async createSearchKeyword(searchKeyword: CreateSearchKeyword): Promise<SearchKeywords> {
+    return this.save(searchKeyword);
   }
 }
 

--- a/backend/src/v1/search-keywords/searchKeywords.service.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.service.ts
@@ -1,12 +1,79 @@
-import { executeQuery, makeExecuteQuery, pool } from '~/mysql';
+import { executeQuery } from '~/mysql';
 import { logger } from '~/logger';
-import { extractHangulInitials, disassembleHangul } from '~/v1/utils/disassembleKeywords';
-import { AutocompleteKeyword, PopularSearchKeyword, SearchKeyword } from './searchKeywords.type';
-import * as searchKeywordRepository from './searchKeywords.repository';
+import jipDataSource from '~/app-data-source';
+import * as errorCode from '~/v1/utils/error/errorCode';
+import {
+  extractHangulInitials,
+  disassembleHangul,
+} from '~/v1/utils/disassembleKeywords';
+import {
+  AutocompleteKeyword,
+  PopularSearchKeyword,
+  SearchKeyword,
+} from './searchKeywords.type';
+import SearchKeywordsRepository from './searchKeywords.repository';
+import SearchLogsRepository from './searchLogs.repository';
 
 const LEAST_SEARCH_COUNT = 5;
 const POPULAR_RANKING_LIMIT = 10;
 let lastPopular: string[] = [];
+
+export const getPopularSearches = async (
+  base: number, // 검색어를 집계할 날짜 기준. ex) 0: 현재 시각부터 집계, 1: 1일 전부터 집계
+  leastSearchCount: string,
+  popularRankingLimit: number,
+) => {
+  const popularSearchKeywords: SearchKeyword[] = await executeQuery(
+    `
+    (
+      SELECT keyword
+      FROM search_logs
+      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
+      WHERE search_logs.timestamp BETWEEN NOW() - INTERVAL 1 DAY - INTERVAL ? DAY AND NOW() - INTERVAL ? DAY 
+      GROUP BY search_keywords.keyword
+      HAVING COUNT(search_keywords.keyword) >= ?
+      ORDER BY COUNT(search_keywords.keyword) DESC, MAX(search_logs.timestamp) DESC
+      LIMIT ?
+    )
+    UNION
+    (
+      SELECT keyword
+      FROM search_logs
+      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
+      WHERE search_logs.timestamp BETWEEN NOW() - INTERVAL 1 MONTH - INTERVAL ? DAY AND NOW() - INTERVAL ? DAY 
+      GROUP BY search_keywords.keyword
+      HAVING COUNT(search_keywords.keyword) >= ?
+      ORDER BY COUNT(search_keywords.keyword) DESC, MAX(search_logs.timestamp) DESC
+      LIMIT ?
+    )
+    UNION
+    (
+      SELECT keyword
+      FROM search_logs
+      LEFT JOIN search_keywords ON search_logs.search_keyword_id = search_keywords.id
+      GROUP BY search_keywords.keyword
+      HAVING COUNT(search_keywords.keyword) >= ?
+      ORDER BY COUNT(search_keywords.keyword) desc, MAX(search_logs.timestamp) desc
+      LIMIT ?
+    )
+    LIMIT ?
+    `,
+    [
+      base,
+      base,
+      leastSearchCount,
+      popularRankingLimit,
+      base,
+      base,
+      leastSearchCount,
+      popularRankingLimit,
+      leastSearchCount,
+      popularRankingLimit,
+      popularRankingLimit,
+    ],
+  );
+  return popularSearchKeywords;
+};
 
 const updateLastPopular = (items: string[]) => {
   lastPopular = [...items];
@@ -16,17 +83,26 @@ const updateLastPopular = (items: string[]) => {
   );
 };
 
+export const renewLastPopular = async () => {
+  const popularSearchKeywords = await getPopularSearches(
+    1,
+    `${LEAST_SEARCH_COUNT}`,
+    POPULAR_RANKING_LIMIT,
+  );
+  updateLastPopular(popularSearchKeywords.map((item) => item.keyword));
+};
+
 export const getPopularSearchKeywords = async () => {
-  const popularKeywords = await searchKeywordRepository.getPopularSearchKeywords(
+  const popularSearchKeywords = await getPopularSearches(
     0,
     `${LEAST_SEARCH_COUNT}`,
     POPULAR_RANKING_LIMIT,
   );
 
   if (!lastPopular || lastPopular.length === 0) {
-    updateLastPopular(popularKeywords.map((item) => item.keyword));
+    updateLastPopular(popularSearchKeywords.map((item) => item.keyword));
   }
-  const items: PopularSearchKeyword[] = popularKeywords.map(
+  const items: PopularSearchKeyword[] = popularSearchKeywords.map(
     (item, index: number) => {
       const preRanking = lastPopular.indexOf(item.keyword);
       return {
@@ -39,72 +115,53 @@ export const getPopularSearchKeywords = async () => {
   return items;
 };
 
-export const renewLastPopular = async () => {
-  const popularKeywords = await searchKeywordRepository.getPopularSearchKeywords(
-    1,
-    `${LEAST_SEARCH_COUNT}`,
-    POPULAR_RANKING_LIMIT,
-  );
-  updateLastPopular(popularKeywords.map((item) => item.keyword));
-};
-
 export const createSearchKeywordLog = async (
   keyword: string,
-  disassemble: string,
-  initials: string,
+  disassembledKeyword: string,
+  initialConsonants: string,
 ) => {
   if (!keyword) return;
 
-  const connection = await pool.getConnection();
-  const transactionExecuteQuery = makeExecuteQuery(connection);
+  const transactionQueryRunner = jipDataSource.createQueryRunner();
+  const searchKeywordsRepository = new SearchKeywordsRepository(
+    transactionQueryRunner,
+  );
+  const searchLogsRepository = new SearchLogsRepository(transactionQueryRunner);
 
   try {
-    await connection.beginTransaction();
-    const [searchKeyword]: [SearchKeyword | undefined] = await transactionExecuteQuery(
-      `
-      SELECT id, keyword
-      FROM search_keywords
-      WHERE keyword = ?
-      `,
-      [keyword],
-    );
+    await transactionQueryRunner.startTransaction();
+    const searchKeyword = await searchKeywordsRepository.findSearchKeyword({
+      keyword,
+    });
 
-    let searchKeywordId = searchKeyword?.id;
-    if (!searchKeyword) {
-      const { insertId }: { insertId: number } = await transactionExecuteQuery(
-        `
-        INSERT INTO search_keywords
-        (keyword, disassembled_keyword, initial_consonants)
-        VALUES (?, ?, ?)
-        `,
-        [keyword, disassemble, initials],
-      );
-      searchKeywordId = insertId;
+    let searchKeywordId: number | undefined;
+    if (searchKeyword) {
+      searchKeywordId = searchKeyword.id;
+    } else {
+      const { id } = await searchKeywordsRepository.createSearchKeyword({
+        keyword,
+        disassembledKeyword,
+        initialConsonants,
+      });
+      searchKeywordId = id;
     }
 
-    await transactionExecuteQuery(
-      `
-      INSERT INTO search_logs
-      (search_keyword_id)
-      VALUES (?)
-      `,
-      [searchKeywordId],
-    );
-
-    await connection.commit();
+    if (!searchKeywordId) {
+      throw new Error(errorCode.QUERY_EXECUTION_FAILED);
+    }
+    await searchLogsRepository.createSearchLog({ searchKeywordId });
+    await transactionQueryRunner.commitTransaction();
   } catch (error) {
-    await connection.rollback();
+    await transactionQueryRunner.rollbackTransaction();
     if (error instanceof Error) {
       throw error;
     }
   } finally {
-    connection.release();
+    await transactionQueryRunner.release();
   }
 };
 
-export const getSearchAutocompletePreviewResult = async (
-  keyword: string,
-) => {
+export const getSearchAutocompletePreviewResult = async (keyword: string) => {
   const LIMIT_OF_SEARCH_KEYWORD_PREVIEW = 12;
   let keywordInitials = extractHangulInitials(keyword as string);
   let isCho = true;
@@ -117,94 +174,117 @@ export const getSearchAutocompletePreviewResult = async (
   let queryResult: AutocompleteKeyword[] = [];
   let totalCount: number;
   if (isCho) {
-    queryResult = await executeQuery(`
+    queryResult = await executeQuery(
+      `
       (
         SELECT id as bookInfoId, title, author, publisher, publishedAt, image
         FROM book_info
         WHERE id IN (
-            SELECT book_info_id
-            FROM book_info_search_keywords
-            WHERE MATCH(title_initials, author_initials, publisher_initials) AGAINST (? IN BOOLEAN MODE)
+          SELECT book_info_id
+          FROM book_info_search_keywords
+          WHERE MATCH(title_initials, author_initials, publisher_initials)
+            AGAINST (? IN BOOLEAN MODE)
         )
-    )
-    UNION (
+      )
+      UNION
+      (
         SELECT id as bookInfoId, title, author, publisher, publishedAt, image
         FROM book_info
         WHERE id IN (
+          SELECT book_info_id
+          FROM book_info_search_keywords
+          WHERE title_initials LIKE ('%${keywordInitials}%')
+            OR author_initials LIKE ('%${keywordInitials}%')
+            OR publisher_initials LIKE ('%${keywordInitials}%')
+        )
+      )
+      LIMIT ${LIMIT_OF_SEARCH_KEYWORD_PREVIEW}
+      `,
+      [keywordInitials],
+    );
+    totalCount = await executeQuery(
+      `
+      SELECT COUNT(*) AS totalCount FROM (
+        (
+          SELECT id
+          FROM book_info
+          WHERE id IN (
+            SELECT book_info_id
+            FROM book_info_search_keywords
+            WHERE MATCH(title_initials, author_initials, publisher_initials)
+              AGAINST (? IN BOOLEAN MODE)
+          )
+        )
+        UNION
+        (
+          SELECT id
+          FROM book_info
+          WHERE id IN (
             SELECT book_info_id
             FROM book_info_search_keywords
             WHERE title_initials LIKE ('%${keywordInitials}%')
-                    OR author_initials LIKE ('%${keywordInitials}%')
-                    OR publisher_initials LIKE ('%${keywordInitials}%')
+              OR author_initials LIKE ('%${keywordInitials}%')
+              OR publisher_initials LIKE ('%${keywordInitials}%')
+          )
         )
-    )
-    LIMIT ${LIMIT_OF_SEARCH_KEYWORD_PREVIEW}
-      `, [keywordInitials]);
-    totalCount = await executeQuery(`SELECT COUNT(*) AS totalCount FROM (
+      ) AS COUNT_SET`,
+      [keywordInitials],
+    ).then((result) => result[0]);
+  } else {
+    queryResult = await executeQuery(
+      `
+      (
+        SELECT id as bookInfoId, title, author, publisher, publishedAt, image
+        FROM book_info
+        WHERE id IN (
+          SELECT book_info_id
+          FROM book_info_search_keywords
+          WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
+        )
+      )
+      UNION
+      (
+        SELECT id as bookInfoId, title, author, publisher, publishedAt, image
+        FROM book_info
+        WHERE id IN (
+          SELECT book_info_id
+          FROM book_info_search_keywords
+          WHERE disassembled_title LIKE ('%${keywordInitials}%')
+            OR disassembled_author LIKE ('%${keywordInitials}%')
+            OR disassembled_publisher LIKE ('%${keywordInitials}%')
+        )
+      )
+      LIMIT ${LIMIT_OF_SEARCH_KEYWORD_PREVIEW}
+      `,
+      [keywordInitials],
+    );
+    totalCount = await executeQuery(
+      `SELECT COUNT(*) AS totalCount FROM (
         (
           SELECT id
           FROM book_info
           WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE MATCH(title_initials, author_initials, publisher_initials) AGAINST (? IN BOOLEAN MODE)
+            SELECT book_info_id
+            FROM book_info_search_keywords
+            WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher)
+              AGAINST (? IN BOOLEAN MODE)
           )
-      )
-      UNION (
+        )
+        UNION
+        (
           SELECT id
           FROM book_info
           WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE title_initials LIKE ('%${keywordInitials}%')
-                      OR author_initials LIKE ('%${keywordInitials}%')
-                      OR publisher_initials LIKE ('%${keywordInitials}%')
-          )
-      )) AS COUNT_SET`, [keywordInitials]).then((result) => result[0]);
-  } else {
-    queryResult = await executeQuery(`(
-        SELECT id as bookInfoId, title, author, publisher, publishedAt, image         
-        FROM book_info
-        WHERE id IN (
-            SELECT book_info_id
-            FROM book_info_search_keywords
-            WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
-        )
-    )
-    UNION (
-        SELECT id as bookInfoId, title, author, publisher, publishedAt, image         
-        FROM book_info
-        WHERE id IN (
             SELECT book_info_id
             FROM book_info_search_keywords
             WHERE disassembled_title LIKE ('%${keywordInitials}%')
-                    OR disassembled_author LIKE ('%${keywordInitials}%')
-                    OR disassembled_publisher LIKE ('%${keywordInitials}%')
+              OR disassembled_author LIKE ('%${keywordInitials}%')
+              OR disassembled_publisher LIKE ('%${keywordInitials}%')
+          )
         )
-    )
-    LIMIT ${LIMIT_OF_SEARCH_KEYWORD_PREVIEW}
-      `, [keywordInitials]);
-    totalCount = await executeQuery(`SELECT COUNT(*) AS totalCount FROM (
-        (
-          SELECT id
-          FROM book_info
-          WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE MATCH(disassembled_title, disassembled_author, disassembled_publisher) AGAINST (? IN BOOLEAN MODE)
-          )
-      )
-      UNION (
-          SELECT id
-          FROM book_info
-          WHERE id IN (
-              SELECT book_info_id
-              FROM book_info_search_keywords
-              WHERE disassembled_title LIKE ('%${keywordInitials}%')
-                      OR disassembled_author LIKE ('%${keywordInitials}%')
-                      OR disassembled_publisher LIKE ('%${keywordInitials}%')
-          )
-      )) AS COUNT_SET`, [keywordInitials]).then((result) => result[0]);
+      ) AS COUNT_SET`,
+      [keywordInitials],
+    ).then((result) => result[0]);
   }
   return {
     items: queryResult,

--- a/backend/src/v1/search-keywords/searchKeywords.type.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.type.ts
@@ -16,3 +16,18 @@ export type AutocompleteKeyword = {
   publishedAt: string;
   image: string;
 };
+
+export type CreateSearchLog = {
+  searchKeywordId: number;
+};
+
+export type CreateSearchKeyword = {
+  keyword: string;
+  disassembledKeyword: string;
+  initialConsonants: string;
+};
+
+export type FindSearchKeyword = {
+  id?: number;
+  keyword?: string;
+};

--- a/backend/src/v1/search-keywords/searchLogs.repository.ts
+++ b/backend/src/v1/search-keywords/searchLogs.repository.ts
@@ -10,10 +10,7 @@ class SearchLogsRepository extends Repository<SearchLogs> {
     super(SearchLogs, entityManager);
   }
 
-  async createSearchLog(target: CreateSearchLog): Promise<SearchLogs> {
-    const searchLog: SearchLogs = {
-      ...target,
-    };
+  async createSearchLog(searchLog: CreateSearchLog): Promise<SearchLogs> {
     return this.save(searchLog);
   }
 }

--- a/backend/src/v1/search-keywords/searchLogs.repository.ts
+++ b/backend/src/v1/search-keywords/searchLogs.repository.ts
@@ -1,0 +1,21 @@
+import { QueryRunner, Repository } from 'typeorm';
+import jipDataSource from '~/app-data-source';
+import { SearchLogs } from '~/entity/entities';
+import { CreateSearchLog } from './searchKeywords.type';
+
+class SearchLogsRepository extends Repository<SearchLogs> {
+  constructor(transactionQueryRunner?: QueryRunner) {
+    const queryRunner = transactionQueryRunner;
+    const entityManager = jipDataSource.createEntityManager(queryRunner);
+    super(SearchLogs, entityManager);
+  }
+
+  async createSearchLog(target: CreateSearchLog): Promise<SearchLogs> {
+    const searchLog: SearchLogs = {
+      ...target,
+    };
+    return this.save(searchLog);
+  }
+}
+
+export default SearchLogsRepository;


### PR DESCRIPTION
### 개요
- #732 

### 작업 사항
- BookInfo와 BookInfoSearchKeywords 엔티티 양방향 관계로 변경
- createSearchKeywordLog TypeORM 적용
- searchKeyword.service raw sql 인덴트 정리

### 변경점
- createSearchKeywordLog을 raw sql 대신 TypeORM 적용

### 목적
- 다른 API와 통일성을 높이기 위함
