### PR TITLE
refactor: like 연산시 공백을 %으로 치환하여 검색

### DIFF
--- a/backend/src/v1/books/books.service.ts
+++ b/backend/src/v1/books/books.service.ts
@@ -166,7 +166,8 @@ export const searchInfo = async (
 ) => {
   const disassemble = query ? disassembleHangul(query) : '';
   const initials = query ? extractHangulInitials(query) : '';
-  const removeBrackets = disassemble.replaceAll('(', '').replaceAll(')', '');
+  const fullTextSearch = disassemble.replaceAll('(', '').replaceAll(')', '');
+  const likeSearch = disassemble.replaceAll(' ', '%').replaceAll(' ', '%');
 
   let matchScore: string;
   let searchCondition: string;
@@ -177,20 +178,20 @@ export const searchInfo = async (
     matchScore = `MATCH(book_info_search_keywords.title_initials,
       book_info_search_keywords.author_initials,
       book_info_search_keywords.publisher_initials)
-      AGAINST ('${removeBrackets}' IN BOOLEAN MODE)`;
+      AGAINST ('${fullTextSearch}' IN BOOLEAN MODE)`;
     searchCondition = `${matchScore}
-      OR book_info_search_keywords.title_initials LIKE '%${initials}%'
-      OR book_info_search_keywords.author_initials LIKE '%${initials}%'
-      OR book_info_search_keywords.publisher_initials LIKE '%${initials}%'`;
+      OR book_info_search_keywords.title_initials LIKE '%${likeSearch}%'
+      OR book_info_search_keywords.author_initials LIKE '%${likeSearch}%'
+      OR book_info_search_keywords.publisher_initials LIKE '%${likeSearch}%'`;
   } else {
     matchScore = `MATCH(book_info_search_keywords.disassembled_title,
       book_info_search_keywords.disassembled_author,
       book_info_search_keywords.disassembled_publisher)
-      AGAINST ('${removeBrackets}' IN BOOLEAN MODE)`;
+      AGAINST ('${fullTextSearch}' IN BOOLEAN MODE)`;
     searchCondition = `${matchScore}
-      OR book_info_search_keywords.disassembled_title LIKE '%${disassemble}%'
-      OR book_info_search_keywords.disassembled_author LIKE '%${disassemble}%'
-      OR book_info_search_keywords.disassembled_publisher LIKE '%${disassemble}%'`;
+      OR book_info_search_keywords.disassembled_title LIKE '%${likeSearch}%'
+      OR book_info_search_keywords.disassembled_author LIKE '%${likeSearch}%'
+      OR book_info_search_keywords.disassembled_publisher LIKE '%${likeSearch}%'`;
   }
 
   let ordering: string;

--- a/backend/src/v1/search-keywords/searchKeywords.service.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.service.ts
@@ -170,7 +170,8 @@ export const getSearchAutocompletePreviewResult = async (keyword: string) => {
     keywordInitials = disassembleHangul(keyword as string);
     isCho = false;
   }
-  const removeBrackets = keywordInitials.replaceAll('(', '').replaceAll(')', '');
+  const fullTextSearch = keywordInitials.replaceAll('(', '').replaceAll(')', '');
+  const likeSearch = keywordInitials.replaceAll(' ', '%').replaceAll(' ', '%');
 
   let queryResult: AutocompleteKeyword[] = [];
   let totalCount: number;
@@ -194,14 +195,14 @@ export const getSearchAutocompletePreviewResult = async (keyword: string) => {
         WHERE id IN (
           SELECT book_info_id
           FROM book_info_search_keywords
-          WHERE title_initials LIKE ('%${keywordInitials}%')
-            OR author_initials LIKE ('%${keywordInitials}%')
-            OR publisher_initials LIKE ('%${keywordInitials}%')
+          WHERE title_initials LIKE ('%${likeSearch}%')
+            OR author_initials LIKE ('%${likeSearch}%')
+            OR publisher_initials LIKE ('%${likeSearch}%')
         )
       )
       LIMIT ${LIMIT_OF_SEARCH_KEYWORD_PREVIEW}
       `,
-      [removeBrackets],
+      [fullTextSearch],
     );
     totalCount = await executeQuery(
       `
@@ -223,13 +224,13 @@ export const getSearchAutocompletePreviewResult = async (keyword: string) => {
           WHERE id IN (
             SELECT book_info_id
             FROM book_info_search_keywords
-            WHERE title_initials LIKE ('%${keywordInitials}%')
-              OR author_initials LIKE ('%${keywordInitials}%')
-              OR publisher_initials LIKE ('%${keywordInitials}%')
+            WHERE title_initials LIKE ('%${likeSearch}%')
+              OR author_initials LIKE ('%${likeSearch}%')
+              OR publisher_initials LIKE ('%${likeSearch}%')
           )
         )
       ) AS COUNT_SET`,
-      [removeBrackets],
+      [fullTextSearch],
     ).then((result) => result[0]);
   } else {
     queryResult = await executeQuery(
@@ -250,14 +251,14 @@ export const getSearchAutocompletePreviewResult = async (keyword: string) => {
         WHERE id IN (
           SELECT book_info_id
           FROM book_info_search_keywords
-          WHERE disassembled_title LIKE ('%${keywordInitials}%')
-            OR disassembled_author LIKE ('%${keywordInitials}%')
-            OR disassembled_publisher LIKE ('%${keywordInitials}%')
+          WHERE disassembled_title LIKE ('%${likeSearch}%')
+            OR disassembled_author LIKE ('%${likeSearch}%')
+            OR disassembled_publisher LIKE ('%${likeSearch}%')
         )
       )
       LIMIT ${LIMIT_OF_SEARCH_KEYWORD_PREVIEW}
       `,
-      [removeBrackets],
+      [fullTextSearch],
     );
     totalCount = await executeQuery(
       `SELECT COUNT(*) AS totalCount FROM (
@@ -278,13 +279,13 @@ export const getSearchAutocompletePreviewResult = async (keyword: string) => {
           WHERE id IN (
             SELECT book_info_id
             FROM book_info_search_keywords
-            WHERE disassembled_title LIKE ('%${keywordInitials}%')
-              OR disassembled_author LIKE ('%${keywordInitials}%')
-              OR disassembled_publisher LIKE ('%${keywordInitials}%')
+            WHERE disassembled_title LIKE ('%${likeSearch}%')
+              OR disassembled_author LIKE ('%${likeSearch}%')
+              OR disassembled_publisher LIKE ('%${likeSearch}%')
           )
         )
       ) AS COUNT_SET`,
-      [removeBrackets],
+      [fullTextSearch],
     ).then((result) => result[0]);
   }
   return {


### PR DESCRIPTION
### 개요
- #741 

### 변경점
- like 연산시 검색어의 공백을 %으로 치환합니다.

### 목적
- 띄어쓰기 유무에 따른 검색 결과 차이를 줄이기 위함입니다.
