### PR TITLE
fix: 빈 문자이거나 공백만 들어오는 경우 return값 형식을 일반 메시지 return과 동일하게 변경

### DIFF
--- a/backend/src/v1/search-keywords/searchKeywords.controller.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.controller.ts
@@ -48,7 +48,7 @@ export const searchKeywordsAutocomplete = async (
   if (!keyword) {
     return res.status(status.OK).send({
       items: [],
-      meta: 0,
+      meta: {totalCount: 0},
     });
   }
   try {

--- a/backend/src/v1/search-keywords/searchKeywords.controller.ts
+++ b/backend/src/v1/search-keywords/searchKeywords.controller.ts
@@ -48,7 +48,7 @@ export const searchKeywordsAutocomplete = async (
   if (!keyword) {
     return res.status(status.OK).send({
       items: [],
-      meta: {totalCount: 0},
+      meta: { totalCount: 0 },
     });
   }
   try {


### PR DESCRIPTION
### 개요
입력되는 검색어가 비어있거나 공백으로만 이루어져 있는 경우 return 값이 일반적인 경우와 달랐던 점

### 작업 사항
일반적인 케이스와 동일하게 return값을 맞춤
![image](https://github.com/jiphyeonjeon-42/backend/assets/74135462/c686bc86-0743-4b5f-a445-e2cc32b3e2e7)
