### PR TITLE
fix(build): typescript를 dependencies로 이전

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
     "dev": "pnpm -r --parallel dev"
   },
   "dependencies": {
+    "typescript": "5.1.6",
     "zod": "^3.22.2",
     "@ts-rest/core": "^3.28.0"
   },
   "devDependencies": {
-    "typescript": "5.1.6",
     "@types/node": "18.16.1",
     "rome": "^12.1.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ts-rest/core':
         specifier: ^3.28.0
         version: 3.28.0(zod@3.22.2)
+      typescript:
+        specifier: 5.1.6
+        version: 5.1.6
       zod:
         specifier: ^3.22.2
         version: 3.22.2
@@ -21,9 +24,6 @@ importers:
       rome:
         specifier: ^12.1.3
         version: 12.1.3
-      typescript:
-        specifier: 5.1.6
-        version: 5.1.6
 
   backend:
     dependencies:


### PR DESCRIPTION
### 개요

- fixes #748

도커파일에서 빌드시 devdependencies를 무시하나 tsc는 빌드에 필요