### PR TITLE
fix(cursus): Access-Control-Allow-Origin 설정

### DIFF
--- a/backend/src/v1/cursus/cursus.service.ts
+++ b/backend/src/v1/cursus/cursus.service.ts
@@ -59,6 +59,8 @@ export const getUserProjectFrom42API = async (
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
+      AccessControlAllowOrigin: 'https://42library.kr',
+      AccessControllAllowCredentials: 'true',
     },
   })
     .then((response) => {
@@ -323,6 +325,8 @@ export const getProjectsInfo = async (accessToken: string, pageNumber: string) =
     .get(`${uri}?${queryString}${pageQuery}`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
+        AccessControlAllowOrigin: 'https://42library.kr',
+        AccessControllAllowCredentials: 'true',
       },
     })
     .catch((error) => {


### PR DESCRIPTION
### 개요
프론트(`42library.kr`)에서 42 API에 요청을 보낼 때, 데이터를 백엔드에서(`/api/cursus/recommend/book`) 응답받으려 할 때 나타나는 504 에러 수정

### 작업 사항
axios로 42 API와 통신 시, 헤더에 `AccessControlAllowOrigin`과 `AccessControllAllowCredentials` 옵션 추가
