### PR TITLE
fix: 스케줄러에 의한 예약 만료 및 재할당 코드

### DIFF
--- a/backend/src/v1/notifications/notifications.service.ts
+++ b/backend/src/v1/notifications/notifications.service.ts
@@ -1,138 +1,24 @@
-import { executeQuery, makeExecuteQuery, pool } from '~/mysql';
+import { executeQuery } from '~/mysql';
 import { publishMessage } from '../slack/slack.service';
+import { handleReservationOverdueAndAssignReservationToNextWaitingUser } from '../reservations/reservations.service';
+import { logger } from '~/logger';
 
-const succeedReservation = async (reservation: { bookId: number; bookInfoId: number }) => {
-  const conn = await pool.getConnection();
-  const transactionExecuteQuery = makeExecuteQuery(conn);
+const sendSlackMessage = async (slack: string, message: string) => {
   try {
-    const candidates: {
-      id: number;
-      slack: string;
-      title: string;
-    }[] = await transactionExecuteQuery(
-      `
-    SELECT
-      reservation.id AS id,
-      user.slack AS slack,
-      book_info.title AS title
-    FROM
-      reservation
-    LEFT JOIN user ON
-      user.id = reservation.userId
-    LEFT JOIN book_info ON
-      book_info.id = reservation.bookInfoId
-    WHERE
-      reservation.status = 0 AND
-      reservation.bookInfoId = ?
-    ORDER BY
-      reservation.createdAt DESC
-    LIMIT 1
-    `,
-      [reservation.bookInfoId],
-    );
-    if (candidates.length !== 0) {
-      await transactionExecuteQuery(
-        `
-        UPDATE
-          reservation
-        SET
-          bookId = ?,
-          endAt = DATE_ADD(NOW(), INTERVAL 3 DAY)
-        WHERE
-          reservation.id = ?
-      `,
-        [reservation.bookId, candidates[0].id],
-      );
-      publishMessage(
-        candidates[0].slack,
-        `:jiphyeonjeon: 예약 알림 :jiphyeonjeon:\n예약하신 도서 \`${candidates[0].title}\`(이)가 대출 가능합니다. 3일 내로 집현전에 방문해 대출해주세요. (방문하시기 전에 비치 여부를 확인해주세요)`,
-      );
-    }
-  } catch (e) {
-    await conn.rollback();
-    if (e instanceof Error) {
-      throw e;
-    }
-  } finally {
-    conn.release();
+    await publishMessage(slack, message);
+  } catch (error) {
+    logger.error('[scheduler error(slack)]', error);
   }
 };
 
-export const notifyReservation = async () => {
-  const reservations: [
-    {
-      bookId: number;
-      bookInfoId: number;
-    },
-  ] = await executeQuery(`
-      SELECT
-        reservation.bookId AS bookId,
-        reservation.bookInfoId AS bookInfoId
-      FROM
-        reservation
-      WHERE
-        reservation.status = 3 AND
-        DATE(reservation.updatedAt) = CURDATE()
-    `);
-  reservations.forEach(async (reservation) => {
-    if (reservation.bookId) {
-      succeedReservation(reservation);
-    }
-  });
-};
-
-export const notifyReservationOverdue = async () => {
-  const reservations: {
-    slack: string;
-    title: string;
-    bookId: number;
-    bookInfoId: number;
-  }[] = await executeQuery(`
-    SELECT
-      user.slack AS slack,
-      book_info.title AS title,
-      reservation.bookId AS bookId,
-      reservation.bookInfoId AS bookInfoId
-    FROM
-      reservation
-    LEFT JOIN user ON
-      user.id = reservation.userId
-    LEFT JOIN book_info ON
-      book_info.id = reservation.bookInfoId
-    WHERE
-      reservation.status = 3 AND
-      DATEDIFF(CURDATE(), DATE(reservation.endAt)) = 1
-  `);
-  reservations.forEach(async (reservation) => {
-    publishMessage(
-      reservation.slack,
-      `:jiphyeonjeon: 예약 만료 알림 :jiphyeonjeon:\n예약하신 도서 \`${reservation.title}\`의 예약이 만료되었습니다.`,
-    );
-    const ranks: [{ id: number; createdAt: Date }] = await executeQuery(
-      `
-      SELECT
-        id,
-        createdAt
-      FROM
-        reservation
-      WHERE
-        bookInfoId = ? AND status = 0
-      ORDER BY createdAt ASC
-    `,
-      [reservation.bookInfoId],
-    );
-    await executeQuery(
-      `
-      UPDATE reservation
-      SET
-        bookId = ?,
-        endAt = ADDDATE(CURDATE(),1)
-      WHERE
-        id = ?
-    `,
-      [reservation.bookId, ranks[0].id],
-    );
-  });
+/**
+ * 만료된 예약을 처리하고, 다음 예약자에게 할당하고, 슬랙 메시지를 전송합니다.
+ * @throws 만료된 예약를 처리하고, 다음 예약자에게 할당하는 쿼리 과정에서 에러가 발생하면 에러를 던집니다. 슬랙 메시지 전송 실패시엔 로그만 남깁니다.
+ */
+export const notifyReservationOverdueAndNotifyReservation = async () => {
+  const { overDueReservations, assignedReservations } = await handleReservationOverdueAndAssignReservationToNextWaitingUser();
+  await Promise.all(overDueReservations.map(({slack, title}) => sendSlackMessage(slack, `:jiphyeonjeon: 예약 만료 알림 :jiphyeonjeon:\n예약하신 도서 \`${title}\`의 예약이 만료되었습니다.`)));
+  await Promise.all(assignedReservations.map((data) => sendSlackMessage(data!.slack, `:jiphyeonjeon: 예약 알림 :jiphyeonjeon:\n예약하신 도서 \`${data!.title}\`(이)가 대출 가능합니다. 3일 내로 집현전에 방문해 대출해주세요.`,)));
 };
 
 export const notifyReturningReminder = async () => {

--- a/backend/src/v1/notifications/notifications.service.ts
+++ b/backend/src/v1/notifications/notifications.service.ts
@@ -17,8 +17,8 @@ const sendSlackMessage = async (slack: string, message: string) => {
  */
 export const notifyReservationOverdueAndNotifyReservation = async () => {
   const { overDueReservations, assignedReservations } = await handleReservationOverdueAndAssignReservationToNextWaitingUser();
-  await Promise.all(overDueReservations.map(({slack, title}) => sendSlackMessage(slack, `:jiphyeonjeon: 예약 만료 알림 :jiphyeonjeon:\n예약하신 도서 \`${title}\`의 예약이 만료되었습니다.`)));
-  await Promise.all(assignedReservations.map((data) => sendSlackMessage(data!.slack, `:jiphyeonjeon: 예약 알림 :jiphyeonjeon:\n예약하신 도서 \`${data!.title}\`(이)가 대출 가능합니다. 3일 내로 집현전에 방문해 대출해주세요.`,)));
+  await Promise.allSettled(overDueReservations.map(({slack, title}) => sendSlackMessage(slack, `:jiphyeonjeon: 예약 만료 알림 :jiphyeonjeon:\n예약하신 도서 \`${title}\`의 예약이 만료되었습니다.`)));
+  await Promise.allSettled(assignedReservations.map((data) => sendSlackMessage(data!.slack, `:jiphyeonjeon: 예약 알림 :jiphyeonjeon:\n예약하신 도서 \`${data!.title}\`(이)가 대출 가능합니다. 3일 내로 집현전에 방문해 대출해주세요.`,)));
 };
 
 export const notifyReturningReminder = async () => {

--- a/backend/src/v1/reservations/reservations.service.ts
+++ b/backend/src/v1/reservations/reservations.service.ts
@@ -224,9 +224,9 @@ const handleReservationOverdue = async (transactionExecuteQuery: TransactionExec
     SET
       status = 3
     WHERE
-      reservation_id IN (
+      reservation.id IN (
         SELECT
-          reservation_id
+          reservation.id
         FROM
           reservation
         WHERE

--- a/backend/src/v1/reservations/reservations.service.ts
+++ b/backend/src/v1/reservations/reservations.service.ts
@@ -257,7 +257,7 @@ const assignReservationToNextWaitingUser = (transactionExecuteQuery: Transaction
     `
     SELECT
       reservation.id AS id,
-      user.slack AS slack,
+      user.slack AS slack
     FROM
       reservation
     LEFT JOIN user ON

--- a/backend/src/v1/reservations/reservations.service.ts
+++ b/backend/src/v1/reservations/reservations.service.ts
@@ -220,6 +220,26 @@ const handleReservationOverdue = async (transactionExecuteQuery: TransactionExec
       IFNULL(DATEDIFF(CURDATE(), DATE(reservation.endAt)), 0) >= 1;
       
   `);
+  await transactionExecuteQuery(`
+    UPDATE
+      reservation
+    SET
+      reservation.status = 3
+    WHERE
+      reservation.id IN (
+        SELECT id
+          FROM (
+            SELECT
+              reservation.id
+            FROM
+              reservation
+            WHERE
+              reservation.status = 0 AND
+              reservation.bookId IS NOT NULL AND
+              IFNULL(DATEDIFF(CURDATE(), DATE(reservation.endAt)), 0) >= 1
+          ) AS expiredReservations
+      );
+  `);
   return overDueReservations;
 }
 

--- a/backend/src/v1/reservations/reservations.service.ts
+++ b/backend/src/v1/reservations/reservations.service.ts
@@ -299,6 +299,7 @@ export const handleReservationOverdueAndAssignReservationToNextWaitingUser = asy
   try {
     const overDueReservations = await handleReservationOverdue(transactionExecuteQuery);
     const assignedReservations = await Promise.all(overDueReservations.map(assignReservationToNextWaitingUser(transactionExecuteQuery)));
+    await conn.commit();
     return { overDueReservations, assignedReservations };
   } catch (error) {
     await conn.rollback();

--- a/backend/src/v1/reservations/reservations.service.ts
+++ b/backend/src/v1/reservations/reservations.service.ts
@@ -187,6 +187,124 @@ export const cancel = async (reservationId: number): Promise<void> => {
   }
 };
 
+type TransactionExecuteQueryType = (queryText: string, values?: any[]) => Promise<any>;
+
+/**
+ * 만료된 예약을 처리 후, 다음 예약자에게 예약을 할당하기 위한 예약 정보를 반환합니다.
+ * - 책이 할당 될때, status는 여전히 0이지만 endAt과 bookId가 null에서 각각 값이 할당됩니다.
+ * - 따라서 status가 0이면서 책이 할당 되어 bookId와 endAt을 가졌으면서 endAt이 현재 날짜보다 이전인 예약을 찾습니다.
+ * - status를 3을 부여하여 만료된 예약임을 표시합니다.
+ * @param transactionExecuteQuery 트랜잭션 처리를 위한 executeQuery
+ */
+const handleReservationOverdue = async (transactionExecuteQuery: TransactionExecuteQueryType) => {
+  const overDueReservations: {
+    slack: string;
+    title: string;
+    bookId: number;
+    bookInfoId: number;
+  }[] = await transactionExecuteQuery(`
+    SELECT
+      user.slack AS slack,
+      book_info.title AS title,
+      reservation.bookId AS bookId,
+      reservation.bookInfoId AS bookInfoId
+    FROM
+      reservation
+    LEFT JOIN user ON
+      user.id = reservation.userId
+    LEFT JOIN book_info ON
+      book_info.id = reservation.bookInfoId
+    WHERE
+      reservation.status = 0 AND
+      bookId IS NOT NULL AND
+      IFNULL(DATEDIFF(CURDATE(), DATE(reservation.endAt)), 0) >= 1
+    FOR UPDATE;
+    UPDATE
+      reservation
+    SET
+      status = 3
+    WHERE
+      reservation_id IN (
+        SELECT
+          reservation_id
+        FROM
+          reservation
+        WHERE
+          reservation.status = 0 AND
+          bookId IS NOT NULL AND
+          IFNULL(DATEDIFF(CURDATE(), DATE(reservation.endAt)), 0) >= 1
+      );
+  `);
+  return overDueReservations;
+}
+
+/**
+ * 예약 취소 시, 다음 예약자에게 예약을 할당합니다.
+ * - 아직 책을 할당 받지 못한 예약자는 status가 0이고, bookId와 endAt이 null입니다.
+ * - 따라서 해당 조건을 만족하면서 가장 먼저 예약한 예약자를 찾아 해당 예약자에게 책을 할당합니다.
+ * @param transactionExecuteQuery 트랜잭션 처리를 위한 executeQuery
+ * @param bookData 책 정보, title, bookId, bookInfoId를 가지고 있습니다. 해당 책은 반드시 예약가능한 상태여야 합니다.
+ * @returns 인자로 받은 transactionExecuteQuery를 이용한 함수를 반환합니다. 해당 함수를 이용해 쿼리를 실행하고, 쿼리 실행 결과를 반환합니다. 반환된 값은 결과를 슬랙 메시지로 안내시 사용가능합니다.
+ */
+const assignReservationToNextWaitingUser = (transactionExecuteQuery: TransactionExecuteQueryType) => async (bookData: {title: string, bookId: number, bookInfoId: number}) => {
+
+  const firstWaitingReservation: { id: number, slack: string }[] = await transactionExecuteQuery(
+    `
+    SELECT
+      reservation.id AS id,
+      user.slack AS slack,
+    FROM
+      reservation
+    LEFT JOIN user ON
+      user.id = reservation.userId
+    WHERE
+      bookInfoId = ? AND status = 0 AND bookId IS NULL AND endAt IS NULL
+    ORDER BY
+      reservation.createdAt ASC
+    LIMIT 1
+    FOR UPDATE;
+  `,
+    [bookData.bookInfoId],
+  );
+  if (firstWaitingReservation.length > 0) {
+    await transactionExecuteQuery(
+      `
+      UPDATE reservation
+      SET
+        bookId = ?,
+        endAt = ADDDATE(CURDATE(), 3)
+      WHERE
+        id = ?;
+    `,
+      [bookData.bookId, firstWaitingReservation[0].id],
+    );
+    return { title: bookData.title, slack: firstWaitingReservation[0].slack };
+  }
+  return null;
+};
+
+/**
+ * 만료된 예약을 처리하고, 다음 예약자에게 할당하고, 슬랙 메시지 전송을 위한 정보를 반환합니다.
+ * @returns 각각 만료된 예약, 다음 예약자에게 할당된 예약 정보를 반환합니다. 해당 정보는 슬랙 메시지 전송을 위해 사용됩니다.
+ */
+export const handleReservationOverdueAndAssignReservationToNextWaitingUser = async() => {
+  const conn = await pool.getConnection();
+  const transactionExecuteQuery = makeExecuteQuery(conn);
+  await conn.beginTransaction();
+  await transactionExecuteQuery('LOCK TABLES lending IN EXCLUSIVE MODE;')
+  try {
+    const overDueReservations = await handleReservationOverdue(transactionExecuteQuery);
+    const assignedReservations = await Promise.all(overDueReservations.map(assignReservationToNextWaitingUser(transactionExecuteQuery)));
+    return { overDueReservations, assignedReservations };
+  } catch (error) {
+    await conn.rollback();
+    throw error;
+  } finally {
+    await transactionExecuteQuery('UNLOCK TABLES lending;')
+    await conn.release();
+  }
+}
+
 export const userCancel = async (userId: number, reservationId: number): Promise<void> => {
   const reservations = await executeQuery(
     `

--- a/backend/src/v1/utils/scheduler.ts
+++ b/backend/src/v1/utils/scheduler.ts
@@ -12,7 +12,6 @@ const midnightScheduler = () => {
   rule.tz = 'Asia/Seoul';
   schedule.scheduleJob(rule, async () => {
     await slack.updateSlackId();
-    await notifications.notifyReservationOverdue();
     await searchKeywords.renewLastPopular();
   });
 };
@@ -24,7 +23,7 @@ const morningScheduler = () => {
   rule.minute = 42;
   rule.tz = 'Asia/Seoul';
   schedule.scheduleJob(rule, async () => {
-    await notifications.notifyReservation();
+    await notifications.notifyReservationOverdueAndNotifyReservation();
     await notifications.notifyReturningReminder();
     await notifications.notifyOverdueManager();
   });


### PR DESCRIPTION
동작 확인 해보지 않은 코드입니다. 테스트 후, 수정이 필요하다면 수정후 반영해주셔야합니다. (제가 개발진이 아니라, 할 수 있는게 없습니다^^.....)

### 개요

fixes #810
스케줄러에서 동작하는 예약 만료 처리 및 재할당하는 코드에서 논리적 문제가 존재하여 올바르게 동작하지 않습니다.

### 작업 사항

scheduler.ts
- notifyReservationOverdue(), notifyReservation()는 하나로 통합되었습니다. notifyReservationOverdueAndNotifyReservation()
- 이와 함꼐 midnightScheduler에서 예약만료처리 코드를 삭제했습니다.
- 슬랙메시지 전송은 낮이 바람직하고, 일련의 처리를 굳이 새벽과 아침에 나누어 작동해야할 필요성을 크게 느끼지 못했습니다.
- 단, 추후 보완한다면 (기존 로직과 동일하게) 새벽시간대  쿼리 관련 로직을 처리하고, 아침시간대 슬랙메시지를 전송하도록 업데이트 할 수 있을것입니다. 

notification.service.ts
- notifyReservationOverdue, notifyReservation 코드는 하나로 통합하였습니다.
- 쿼리 구현부 코드는 모두 reservations.service.ts 에 새롭게 작성된 함수로 대체하였습니다. 이에따라 succeedReservation() 코드는 삭제되었습니다.
- 쿼리 실행 과정에서 오류 발생시 에러를 던집니다. 슬랙 메시지 전송 과정에서 에러가 발생하면 로그만 남깁니다.

reservations.service.ts
- 총 3개의 함수가 추가되었습니다.
- handleReservationOverdueAndAssignReservationToNextWaitingUser는 트랜잭션을 설정하고, 슬랙 메시지 전송을 위해 수행 결과를 반환합니다.
- handleReservationOverdue는 예약 만료 처리를 한 뒤, 해당 예약 정보를 반환합니다.
- assignReservationToNextWaitingUser는 만료된 예약정보를 받아 다음 예약자에게 할당합니다.

handleReservationOverdueAndAssignReservationToNextWaitingUser()
- 예약 만료 처리와 다음 예약자에게 할당하는 것이 하나의 트랜잭션안에서 수행되도록 설정합니다.
- 사이드 이펙트 방지를 위해 로직을 처리하는 동안 lending에 ROCK을 설정합니다.

handleReservationOverdue()
- 기존 코드의 논리적 오류를 수정했습니다.
- 예약 만료 처리해야할 데이터 조회 로직을 수정했습니다. status가 3이 아니라, 0이면서 && 책이 할당되었으면서 && 만료일이 지난 예약을 찾습니다.
- 이제 이곳에서 정상적으로 예약만료 처리과정에서 status = 3을 부여합니다.

assignReservationToNextWaitingUser()
- 기존 코드의 논리적 오류를 수정했습니다.
- 다음 예약자를 찾기위한 데이터 조회 로직을 수정했습니다. bookId와 endAt이 null인지 조건이 추가되었습니다.
- 해당 책에 대해서 다음 예약자가 존재하면 할당합니다.
- handleReservationOverdue()를 통해 예약 만료된 책 정보를 1개씩 입력받습니다.

### 변경점

backend/src/v1 내
- notifications/notifications.service.ts
- reservations/reservations.service.ts
- utils/scheduler.ts

### 목적

올바르게 작동하도록 수정을 진행했습니다.

### 스크린샷 (optional)
